### PR TITLE
prevent undef value if ipv6 is turned off, fail if not etcd_servers are defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ should be able to handle both older and newer versions without issues.
 
 ## Usage
 
+Set k8s::server::etcd_servers to a list of servers or k8s::puppetdb_discovery to `true`.
+
 Setting up a server node (apiserver, controller-manager, scheduler);
 ```puppet
 class { 'k8s':

--- a/data/rspec.yaml
+++ b/data/rspec.yaml
@@ -1,0 +1,2 @@
+---
+k8s::server::etcd_servers: ['https://localhost:2379']

--- a/hiera-rspec.yaml
+++ b/hiera-rspec.yaml
@@ -1,0 +1,10 @@
+---
+version: 5
+
+defaults:  # Used for any hierarchy level that omits these keys.
+  datadir: data         # This path is relative to hiera.yaml's directory.
+  data_hash: yaml_data  # Use the built-in YAML backend.
+
+hierarchy:
+  - name: 'rspec'
+    path: 'rspec.yaml'

--- a/manifests/binary.pp
+++ b/manifests/binary.pp
@@ -136,9 +136,10 @@ define k8s::binary (
       }
     } else {
       file { "/usr/bin/${name}":
-        ensure => $ensure,
-        mode   => '0755',
-        target => "${target}/${name}",
+        ensure  => link,
+        mode    => '0755',
+        replace => true,
+        target  => "${target}/${name}",
       }
     }
   }

--- a/manifests/server/apiserver.pp
+++ b/manifests/server/apiserver.pp
@@ -32,6 +32,10 @@ class k8s::server::apiserver (
     ensure => $ensure,
   }
 
+  unless $discover_etcd_servers or $etcd_servers {
+    fail('please specify $etcd_servers or activate $discover_etcd_servers')
+  }
+
   if $discover_etcd_servers and !$etcd_servers {
     # Needs the PuppetDB terminus installed
     $pql_query = [

--- a/manifests/server/etcd.pp
+++ b/manifests/server/etcd.pp
@@ -31,6 +31,16 @@ class k8s::server::etcd (
       }
     }
 
+    $addn_names = [
+      fact('networking.hostname'),
+      fact('networking.fqdn'),
+      fact('networking.ip'),
+      fact('networking.ip6'),
+      'localhost',
+      '127.0.0.1',
+      '::1',
+    ]
+
     k8s::server::tls::ca {
       default:
         ensure   => $ensure,
@@ -57,15 +67,7 @@ class k8s::server::etcd (
       'etcd-server':
         ca_key             => $client_ca_key,
         ca_cert            => $client_ca_cert,
-        addn_names         => [
-          fact('networking.hostname'),
-          fact('networking.fqdn'),
-          fact('networking.ip'),
-          fact('networking.ip6'),
-          'localhost',
-          '127.0.0.1',
-          '::1',
-        ],
+        addn_names         => delete_undef_values($addn_names), # prevent undef value if ipv6 is turned off
         distinguished_name => {
           commonName => fact('networking.fqdn'),
         },
@@ -74,15 +76,7 @@ class k8s::server::etcd (
       'etcd-peer':
         ca_key             => $peer_ca_key,
         ca_cert            => $peer_ca_cert,
-        addn_names         => [
-          fact('networking.hostname'),
-          fact('networking.fqdn'),
-          fact('networking.ip'),
-          fact('networking.ip6'),
-          'localhost',
-          '127.0.0.1',
-          '::1',
-        ],
+        addn_names         => delete_undef_values($addn_names), # prevent undef value if ipv6 is turned off
         distinguished_name => {
           commonName => fact('networking.fqdn'),
         },

--- a/manifests/server/tls.pp
+++ b/manifests/server/tls.pp
@@ -92,21 +92,26 @@ class k8s::server::tls (
 
       'kube-apiserver':
         extended_key_usage => ['serverAuth'],
-        addn_names         => ([
-            'kubernetes',
-            'kubernetes.default',
-            'kubernetes.default.svc',
-            "kubernetes.default.svc.${cluster_domain}",
-            'kubernetes.service.discover',
-            'localhost',
-            fact('networking.hostname'),
-            fact('networking.fqdn'),
-            $api_service_address,
-            '127.0.0.1',
-            '::1',
-            fact('networking.ip'),
-            fact('networking.ip6'),
-        ] + $api_addn_names).unique(),
+        # prevent undef value if ipv6 is turned off
+        addn_names         => delete_undef_values(
+          (
+            [
+              'kubernetes',
+              'kubernetes.default',
+              'kubernetes.default.svc',
+              "kubernetes.default.svc.${cluster_domain}",
+              'kubernetes.service.discover',
+              'localhost',
+              fact('networking.hostname'),
+              fact('networking.fqdn'),
+              $api_service_address,
+              '127.0.0.1',
+              '::1',
+              fact('networking.ip'),
+              fact('networking.ip6'),
+            ] + $api_addn_names
+          ).unique()
+        ),
         distinguished_name => {
           commonName => 'kube-apiserver',
         };
@@ -141,11 +146,14 @@ class k8s::server::tls (
 
       'node':
         extended_key_usage => ['serverAuth', 'clientAuth'],
-        addn_names         => [
-          fact('networking.fqdn'),
-          fact('networking.ip'),
-          fact('networking.ip6'),
-        ],
+        # prevent undef value if ipv6 is turned off
+        addn_names         => delete_undef_values(
+          [
+            fact('networking.fqdn'),
+            fact('networking.ip'),
+            fact('networking.ip6'),
+          ]
+        ),
         distinguished_name => {
           organizationName => 'system:nodes',
           commonName       => "system:node:${fact('networking.fqdn')}",

--- a/spec/classes/k8s_spec.rb
+++ b/spec/classes/k8s_spec.rb
@@ -6,6 +6,7 @@ describe 'k8s' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
+      let(:hiera_config) { 'hiera-rspec.yaml' }
 
       it { is_expected.to compile }
 

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -5,13 +5,14 @@ require 'spec_helper'
 describe 'k8s::server' do
   let(:pre_condition) do
     <<~PUPPET
-      include ::k8s
+      include k8s
     PUPPET
   end
 
   let(:params) do
     {
-      node_on_server: false
+      node_on_server: false,
+      etcd_servers: ['https://localhost:2379']
     }
   end
 

--- a/spec/defines/binary_spec.rb
+++ b/spec/defines/binary_spec.rb
@@ -48,7 +48,7 @@ describe 'k8s::binary' do
                 it do
                   is_expected.to contain_file("/usr/bin/#{binary}").with(
                     ensure: 'present',
-                    mode: '0755',
+                    mode: '0755'
                   )
                 end
               else
@@ -57,7 +57,7 @@ describe 'k8s::binary' do
                     ensure: 'link',
                     mode: '0755',
                     replace: true,
-                    target: "/opt/k8s/1.0/#{binary}",
+                    target: "/opt/k8s/1.0/#{binary}"
                   )
                 end
               end

--- a/spec/defines/binary_spec.rb
+++ b/spec/defines/binary_spec.rb
@@ -11,7 +11,7 @@ describe 'k8s::binary' do
   end
 
   let(:pre_condition) do
-    'include ::k8s'
+    'include k8s'
   end
 
   on_supported_os.each do |os, os_facts|
@@ -44,11 +44,22 @@ describe 'k8s::binary' do
                 )
               end
 
-              it do
-                is_expected.to contain_file("/usr/bin/#{binary}").with(
-                  ensure: 'present',
-                  mode: '0755'
-                )
+              if method == 'package'
+                it do
+                  is_expected.to contain_file("/usr/bin/#{binary}").with(
+                    ensure: 'present',
+                    mode: '0755',
+                  )
+                end
+              else
+                it do
+                  is_expected.to contain_file("/usr/bin/#{binary}").with(
+                    ensure: 'link',
+                    mode: '0755',
+                    replace: true,
+                    target: "/opt/k8s/1.0/#{binary}",
+                  )
+                end
               end
 
               case method


### PR DESCRIPTION
- prevent undef value if ipv6 is turned off
- fail if no etcd_servers are defined
- add proper links

i know, ci is failing, but want to know first if it would be okay like that?

## why

### prevent undef in addn_names

if ipv6 is not available fact('networking.ip6') returns Undef and this breaks the typ TLS_Altnames.

### fail if no etcd

does it make sense to run without etcd_servers nor discover_etcd_servers set to true?

### proper links
atm i get 0 bytes files if i dont set it like this, how is this supposed to be? if one sets ensure to present but no source/content this will be an empty file. target alone does not make it a link.
