### PR TITLE
Patching v3

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -7,6 +7,8 @@
 ### Classes
 
 * [`k8s`](#k8s): Sets up a Kubernetes instance - either as a node or as a server
+* [`k8s::install::kubeadm`](#k8s--install--kubeadm): Installs the kubeadm binary
+* [`k8s::install::kubectl`](#k8s--install--kubectl): Installs the kubectl binary
 * [`k8s::node`](#k8s--node): Installs a Kubernetes node
 * [`k8s::node::kube_proxy`](#k8s--node--kube_proxy): Sets up a on-node kube-proxy instance
 * [`k8s::node::kubectl`](#k8s--node--kubectl): Installs the kubectl binary
@@ -47,6 +49,7 @@
 * [`K8s::Duration`](#K8s--Duration): This regexp matches Go duration values, as taken from;
 * [`K8s::Ensure`](#K8s--Ensure): a type to describe the ensure pattern
 * [`K8s::Extended_key_usage`](#K8s--Extended_key_usage): a type to describe extended key usage for a TLS certificate
+* [`K8s::Firewall`](#K8s--Firewall): a type to describe the type of the firewall to use
 * [`K8s::IP_addresses`](#K8s--IP_addresses): a type to describe multiple IP addresses without subnet sizes
 * [`K8s::Native_packaging`](#K8s--Native_packaging): a type to describe Kubernetes native packaging methods
 * [`K8s::Node_auth`](#K8s--Node_auth): a type to describe node/kubelet authentication methods
@@ -106,6 +109,7 @@ The following parameters are available in the `k8s` class:
 * [`dns_service_address`](#-k8s--dns_service_address)
 * [`cluster_domain`](#-k8s--cluster_domain)
 * [`role`](#-k8s--role)
+* [`firewall_type`](#-k8s--firewall_type)
 
 ##### <a name="-k8s--manage_kernel_modules"></a>`manage_kernel_modules`
 
@@ -411,6 +415,50 @@ Data type: `Enum['node','server','none']`
 
 Default value: `'none'`
 
+##### <a name="-k8s--firewall_type"></a>`firewall_type`
+
+Data type: `K8s::Firewall`
+
+
+
+Default value: `'firewalld'`
+
+### <a name="k8s--install--kubeadm"></a>`k8s::install::kubeadm`
+
+Installs the kubeadm binary
+
+#### Parameters
+
+The following parameters are available in the `k8s::install::kubeadm` class:
+
+* [`ensure`](#-k8s--install--kubeadm--ensure)
+
+##### <a name="-k8s--install--kubeadm--ensure"></a>`ensure`
+
+Data type: `K8s::Ensure`
+
+set ensure for installation or deinstallation
+
+Default value: `$k8s::ensure`
+
+### <a name="k8s--install--kubectl"></a>`k8s::install::kubectl`
+
+Installs the kubectl binary
+
+#### Parameters
+
+The following parameters are available in the `k8s::install::kubectl` class:
+
+* [`ensure`](#-k8s--install--kubectl--ensure)
+
+##### <a name="-k8s--install--kubectl--ensure"></a>`ensure`
+
+Data type: `K8s::Ensure`
+
+set ensure for installation or deinstallation
+
+Default value: `$k8s::ensure`
+
 ### <a name="k8s--node"></a>`k8s::node`
 
 Installs a Kubernetes node
@@ -437,6 +485,7 @@ The following parameters are available in the `k8s::node` class:
 * [`proxy_key`](#-k8s--node--proxy_key)
 * [`node_token`](#-k8s--node--node_token)
 * [`proxy_token`](#-k8s--node--proxy_token)
+* [`firewall_type`](#-k8s--node--firewall_type)
 
 ##### <a name="-k8s--node--ensure"></a>`ensure`
 
@@ -581,6 +630,14 @@ Data type: `Optional[String[1]]`
 
 
 Default value: `undef`
+
+##### <a name="-k8s--node--firewall_type"></a>`firewall_type`
+
+Data type: `K8s::Firewall`
+
+
+
+Default value: `$k8s::firewall_type`
 
 ### <a name="k8s--node--kube_proxy"></a>`k8s::node::kube_proxy`
 
@@ -735,6 +792,7 @@ The following parameters are available in the `k8s::node::kubelet` class:
 * [`cert`](#-k8s--node--kubelet--cert)
 * [`key`](#-k8s--node--kubelet--key)
 * [`token`](#-k8s--node--kubelet--token)
+* [`firewall_type`](#-k8s--node--kubelet--firewall_type)
 
 ##### <a name="-k8s--node--kubelet--ensure"></a>`ensure`
 
@@ -888,6 +946,14 @@ Data type: `Optional[String[1]]`
 
 Default value: `$k8s::node::node_token`
 
+##### <a name="-k8s--node--kubelet--firewall_type"></a>`firewall_type`
+
+Data type: `K8s::Firewall`
+
+
+
+Default value: `$k8s::node::firewall_type`
+
 ### <a name="k8s--repo"></a>`k8s::repo`
 
 Handles repositories for the container runtime
@@ -903,7 +969,7 @@ The following parameters are available in the `k8s::repo` class:
 
 Data type: `Boolean`
 
-wether to add cri-o repository or not
+whether to add cri-o repository or not
 
 Default value: `$k8s::manage_container_manager`
 
@@ -935,11 +1001,13 @@ The following parameters are available in the `k8s::server` class:
 * [`dns_service_address`](#-k8s--server--dns_service_address)
 * [`ensure`](#-k8s--server--ensure)
 * [`etcd_servers`](#-k8s--server--etcd_servers)
+* [`firewall_type`](#-k8s--server--firewall_type)
 * [`generate_ca`](#-k8s--server--generate_ca)
 * [`manage_certs`](#-k8s--server--manage_certs)
 * [`manage_components`](#-k8s--server--manage_components)
 * [`manage_etcd`](#-k8s--server--manage_etcd)
 * [`manage_firewall`](#-k8s--server--manage_firewall)
+* [`manage_kubeadm`](#-k8s--server--manage_kubeadm)
 * [`manage_resources`](#-k8s--server--manage_resources)
 * [`manage_signing`](#-k8s--server--manage_signing)
 * [`master`](#-k8s--server--master)
@@ -1030,7 +1098,7 @@ Default value: `$k8s::dns_service_address`
 
 Data type: `K8s::Ensure`
 
-
+set ensure for installation or deinstallation
 
 Default value: `$k8s::ensure`
 
@@ -1041,6 +1109,14 @@ Data type: `Optional[Array[Stdlib::HTTPUrl]]`
 list etcd servers if no puppetdb is used
 
 Default value: `undef`
+
+##### <a name="-k8s--server--firewall_type"></a>`firewall_type`
+
+Data type: `K8s::Firewall`
+
+define the type of firewall to use
+
+Default value: `$k8s::firewall_type`
 
 ##### <a name="-k8s--server--generate_ca"></a>`generate_ca`
 
@@ -1054,7 +1130,7 @@ Default value: `false`
 
 Data type: `Boolean`
 
-wether to manage certs or not
+whether to manage certs or not
 
 Default value: `true`
 
@@ -1062,7 +1138,7 @@ Default value: `true`
 
 Data type: `Boolean`
 
-wether to manage components or not
+whether to manage components or not
 
 Default value: `true`
 
@@ -1070,7 +1146,7 @@ Default value: `true`
 
 Data type: `Boolean`
 
-wether to manage etcd or not
+whether to manage etcd or not
 
 Default value: `$k8s::manage_etcd`
 
@@ -1078,15 +1154,23 @@ Default value: `$k8s::manage_etcd`
 
 Data type: `Boolean`
 
-wether to manage firewall or not
+whether to manage firewall or not
 
 Default value: `$k8s::manage_firewall`
+
+##### <a name="-k8s--server--manage_kubeadm"></a>`manage_kubeadm`
+
+Data type: `Boolean`
+
+whether to install kubeadm or not
+
+Default value: `false`
 
 ##### <a name="-k8s--server--manage_resources"></a>`manage_resources`
 
 Data type: `Boolean`
 
-wether to manage cluster internal resources or not
+whether to manage cluster internal resources or not
 
 Default value: `true`
 
@@ -1094,7 +1178,7 @@ Default value: `true`
 
 Data type: `Boolean`
 
-wether to manage cert signing or not
+whether to manage cert signing or not
 
 Default value: `$k8s::puppetdb_discovery`
 
@@ -1110,7 +1194,7 @@ Default value: `$k8s::master`
 
 Data type: `Boolean`
 
-wether to use controller also as nodes or not
+whether to use controller also as nodes or not
 
 Default value: `true`
 
@@ -1152,6 +1236,7 @@ The following parameters are available in the `k8s::server::apiserver` class:
 * [`etcd_cert`](#-k8s--server--apiserver--etcd_cert)
 * [`etcd_key`](#-k8s--server--apiserver--etcd_key)
 * [`advertise_address`](#-k8s--server--apiserver--advertise_address)
+* [`firewall_type`](#-k8s--server--apiserver--firewall_type)
 
 ##### <a name="-k8s--server--apiserver--ensure"></a>`ensure`
 
@@ -1329,6 +1414,14 @@ Data type: `Stdlib::IP::Address::Nosubnet`
 
 Default value: `fact('networking.ip')`
 
+##### <a name="-k8s--server--apiserver--firewall_type"></a>`firewall_type`
+
+Data type: `K8s::Firewall`
+
+
+
+Default value: `$k8s::server::firewall_type`
+
 ### <a name="k8s--server--controller_manager"></a>`k8s::server::controller_manager`
 
 Installs and configures a Kubernetes controller manager
@@ -1451,6 +1544,7 @@ The following parameters are available in the `k8s::server::etcd` class:
 * [`peer_ca_cert`](#-k8s--server--etcd--peer_ca_cert)
 * [`client_ca_key`](#-k8s--server--etcd--client_ca_key)
 * [`client_ca_cert`](#-k8s--server--etcd--client_ca_cert)
+* [`firewall_type`](#-k8s--server--etcd--firewall_type)
 
 ##### <a name="-k8s--server--etcd--ensure"></a>`ensure`
 
@@ -1571,6 +1665,14 @@ Data type: `Stdlib::Unixpath`
 
 
 Default value: `"${cert_path}/client-ca.pem"`
+
+##### <a name="-k8s--server--etcd--firewall_type"></a>`firewall_type`
+
+Data type: `K8s::Firewall`
+
+
+
+Default value: `$k8s::server::firewall_type`
 
 ### <a name="k8s--server--etcd--setup"></a>`k8s::server::etcd::setup`
 
@@ -3092,6 +3194,12 @@ Array[Enum[
     'serverAuth'
   ]]
 ```
+
+### <a name="K8s--Firewall"></a>`K8s::Firewall`
+
+a type to describe the type of the firewall to use
+
+Alias of `Enum['iptables', 'firewalld']`
 
 ### <a name="K8s--IP_addresses"></a>`K8s::IP_addresses`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -467,79 +467,63 @@ Installs a Kubernetes node
 
 The following parameters are available in the `k8s::node` class:
 
+* [`ca_cert`](#-k8s--node--ca_cert)
+* [`cert_path`](#-k8s--node--cert_path)
 * [`ensure`](#-k8s--node--ensure)
-* [`master`](#-k8s--node--master)
-* [`node_auth`](#-k8s--node--node_auth)
-* [`proxy_auth`](#-k8s--node--proxy_auth)
-* [`manage_kubelet`](#-k8s--node--manage_kubelet)
-* [`manage_proxy`](#-k8s--node--manage_proxy)
+* [`firewall_type`](#-k8s--node--firewall_type)
 * [`manage_firewall`](#-k8s--node--manage_firewall)
 * [`manage_kernel_modules`](#-k8s--node--manage_kernel_modules)
+* [`manage_kubelet`](#-k8s--node--manage_kubelet)
+* [`manage_proxy`](#-k8s--node--manage_proxy)
 * [`manage_sysctl_settings`](#-k8s--node--manage_sysctl_settings)
-* [`puppetdb_discovery_tag`](#-k8s--node--puppetdb_discovery_tag)
-* [`cert_path`](#-k8s--node--cert_path)
-* [`ca_cert`](#-k8s--node--ca_cert)
+* [`master`](#-k8s--node--master)
+* [`node_auth`](#-k8s--node--node_auth)
 * [`node_cert`](#-k8s--node--node_cert)
 * [`node_key`](#-k8s--node--node_key)
+* [`node_token`](#-k8s--node--node_token)
+* [`proxy_auth`](#-k8s--node--proxy_auth)
 * [`proxy_cert`](#-k8s--node--proxy_cert)
 * [`proxy_key`](#-k8s--node--proxy_key)
-* [`node_token`](#-k8s--node--node_token)
 * [`proxy_token`](#-k8s--node--proxy_token)
-* [`firewall_type`](#-k8s--node--firewall_type)
+* [`puppetdb_discovery_tag`](#-k8s--node--puppetdb_discovery_tag)
+
+##### <a name="-k8s--node--ca_cert"></a>`ca_cert`
+
+Data type: `Stdlib::Unixpath`
+
+path to the ca cert
+
+Default value: `"${cert_path}/ca.pem"`
+
+##### <a name="-k8s--node--cert_path"></a>`cert_path`
+
+Data type: `Stdlib::Unixpath`
+
+path to cert files
+
+Default value: `'/var/lib/kubelet/pki'`
 
 ##### <a name="-k8s--node--ensure"></a>`ensure`
 
 Data type: `K8s::Ensure`
 
-
+set ensure for installation or deinstallation
 
 Default value: `$k8s::ensure`
 
-##### <a name="-k8s--node--master"></a>`master`
+##### <a name="-k8s--node--firewall_type"></a>`firewall_type`
 
-Data type: `Stdlib::HTTPUrl`
+Data type: `K8s::Firewall`
 
+define the type of firewall to use
 
-
-Default value: `$k8s::master`
-
-##### <a name="-k8s--node--node_auth"></a>`node_auth`
-
-Data type: `K8s::Node_auth`
-
-
-
-Default value: `$k8s::node_auth`
-
-##### <a name="-k8s--node--proxy_auth"></a>`proxy_auth`
-
-Data type: `K8s::Proxy_auth`
-
-
-
-Default value: `'incluster'`
-
-##### <a name="-k8s--node--manage_kubelet"></a>`manage_kubelet`
-
-Data type: `Boolean`
-
-
-
-Default value: `true`
-
-##### <a name="-k8s--node--manage_proxy"></a>`manage_proxy`
-
-Data type: `Boolean`
-
-
-
-Default value: `false`
+Default value: `$k8s::firewall_type`
 
 ##### <a name="-k8s--node--manage_firewall"></a>`manage_firewall`
 
 Data type: `Boolean`
 
-
+whether to manage firewall or not
 
 Default value: `$k8s::manage_firewall`
 
@@ -547,47 +531,55 @@ Default value: `$k8s::manage_firewall`
 
 Data type: `Boolean`
 
-
+whether to load kernel modules or not
 
 Default value: `$k8s::manage_kernel_modules`
+
+##### <a name="-k8s--node--manage_kubelet"></a>`manage_kubelet`
+
+Data type: `Boolean`
+
+whether to manage kublet or not
+
+Default value: `true`
+
+##### <a name="-k8s--node--manage_proxy"></a>`manage_proxy`
+
+Data type: `Boolean`
+
+whether to manage kube-proxy or not
+
+Default value: `false`
 
 ##### <a name="-k8s--node--manage_sysctl_settings"></a>`manage_sysctl_settings`
 
 Data type: `Boolean`
 
-
+whether to manage sysctl settings or not
 
 Default value: `$k8s::manage_sysctl_settings`
 
-##### <a name="-k8s--node--puppetdb_discovery_tag"></a>`puppetdb_discovery_tag`
+##### <a name="-k8s--node--master"></a>`master`
 
-Data type: `String[1]`
+Data type: `Stdlib::HTTPUrl`
 
+cluster API connection
 
+Default value: `$k8s::master`
 
-Default value: `$k8s::puppetdb_discovery_tag`
+##### <a name="-k8s--node--node_auth"></a>`node_auth`
 
-##### <a name="-k8s--node--cert_path"></a>`cert_path`
+Data type: `K8s::Node_auth`
 
-Data type: `Stdlib::Unixpath`
+type of node authentication
 
-
-
-Default value: `'/var/lib/kubelet/pki'`
-
-##### <a name="-k8s--node--ca_cert"></a>`ca_cert`
-
-Data type: `Stdlib::Unixpath`
-
-
-
-Default value: `"${cert_path}/ca.pem"`
+Default value: `$k8s::node_auth`
 
 ##### <a name="-k8s--node--node_cert"></a>`node_cert`
 
 Data type: `Optional[Stdlib::Unixpath]`
 
-
+path to node cert file
 
 Default value: `undef`
 
@@ -595,23 +587,7 @@ Default value: `undef`
 
 Data type: `Optional[Stdlib::Unixpath]`
 
-
-
-Default value: `undef`
-
-##### <a name="-k8s--node--proxy_cert"></a>`proxy_cert`
-
-Data type: `Optional[Stdlib::Unixpath]`
-
-
-
-Default value: `undef`
-
-##### <a name="-k8s--node--proxy_key"></a>`proxy_key`
-
-Data type: `Optional[Stdlib::Unixpath]`
-
-
+path to node key file
 
 Default value: `undef`
 
@@ -619,7 +595,31 @@ Default value: `undef`
 
 Data type: `Optional[String[1]]`
 
+k8s token to join a cluster
 
+Default value: `undef`
+
+##### <a name="-k8s--node--proxy_auth"></a>`proxy_auth`
+
+Data type: `K8s::Proxy_auth`
+
+which proxy auth to use
+
+Default value: `'incluster'`
+
+##### <a name="-k8s--node--proxy_cert"></a>`proxy_cert`
+
+Data type: `Optional[Stdlib::Unixpath]`
+
+path to proxy cert file
+
+Default value: `undef`
+
+##### <a name="-k8s--node--proxy_key"></a>`proxy_key`
+
+Data type: `Optional[Stdlib::Unixpath]`
+
+path to proxy key file
 
 Default value: `undef`
 
@@ -627,17 +627,17 @@ Default value: `undef`
 
 Data type: `Optional[String[1]]`
 
-
+k8s token for kube-proxy
 
 Default value: `undef`
 
-##### <a name="-k8s--node--firewall_type"></a>`firewall_type`
+##### <a name="-k8s--node--puppetdb_discovery_tag"></a>`puppetdb_discovery_tag`
 
-Data type: `K8s::Firewall`
+Data type: `String[1]`
 
+enable puppetdb resource searching
 
-
-Default value: `$k8s::firewall_type`
+Default value: `$k8s::puppetdb_discovery_tag`
 
 ### <a name="k8s--node--kube_proxy"></a>`k8s::node::kube_proxy`
 
@@ -773,50 +773,26 @@ Installs and configures kubelet
 
 The following parameters are available in the `k8s::node::kubelet` class:
 
-* [`ensure`](#-k8s--node--kubelet--ensure)
-* [`master`](#-k8s--node--kubelet--master)
-* [`config`](#-k8s--node--kubelet--config)
 * [`arguments`](#-k8s--node--kubelet--arguments)
-* [`runtime`](#-k8s--node--kubelet--runtime)
-* [`runtime_service`](#-k8s--node--kubelet--runtime_service)
-* [`puppetdb_discovery_tag`](#-k8s--node--kubelet--puppetdb_discovery_tag)
 * [`auth`](#-k8s--node--kubelet--auth)
-* [`rotate_server_tls`](#-k8s--node--kubelet--rotate_server_tls)
+* [`ca_cert`](#-k8s--node--kubelet--ca_cert)
+* [`cert`](#-k8s--node--kubelet--cert)
+* [`cert_path`](#-k8s--node--kubelet--cert_path)
+* [`config`](#-k8s--node--kubelet--config)
+* [`ensure`](#-k8s--node--kubelet--ensure)
+* [`firewall_type`](#-k8s--node--kubelet--firewall_type)
+* [`key`](#-k8s--node--kubelet--key)
+* [`kubeconfig`](#-k8s--node--kubelet--kubeconfig)
 * [`manage_firewall`](#-k8s--node--kubelet--manage_firewall)
 * [`manage_kernel_modules`](#-k8s--node--kubelet--manage_kernel_modules)
 * [`manage_sysctl_settings`](#-k8s--node--kubelet--manage_sysctl_settings)
+* [`master`](#-k8s--node--kubelet--master)
+* [`puppetdb_discovery_tag`](#-k8s--node--kubelet--puppetdb_discovery_tag)
+* [`rotate_server_tls`](#-k8s--node--kubelet--rotate_server_tls)
+* [`runtime`](#-k8s--node--kubelet--runtime)
+* [`runtime_service`](#-k8s--node--kubelet--runtime_service)
 * [`support_dualstack`](#-k8s--node--kubelet--support_dualstack)
-* [`cert_path`](#-k8s--node--kubelet--cert_path)
-* [`kubeconfig`](#-k8s--node--kubelet--kubeconfig)
-* [`ca_cert`](#-k8s--node--kubelet--ca_cert)
-* [`cert`](#-k8s--node--kubelet--cert)
-* [`key`](#-k8s--node--kubelet--key)
 * [`token`](#-k8s--node--kubelet--token)
-* [`firewall_type`](#-k8s--node--kubelet--firewall_type)
-
-##### <a name="-k8s--node--kubelet--ensure"></a>`ensure`
-
-Data type: `K8s::Ensure`
-
-
-
-Default value: `$k8s::node::ensure`
-
-##### <a name="-k8s--node--kubelet--master"></a>`master`
-
-Data type: `Stdlib::HTTPUrl`
-
-
-
-Default value: `$k8s::node::master`
-
-##### <a name="-k8s--node--kubelet--config"></a>`config`
-
-Data type: `Hash[String, Data]`
-
-
-
-Default value: `{}`
 
 ##### <a name="-k8s--node--kubelet--arguments"></a>`arguments`
 
@@ -826,37 +802,117 @@ Data type: `Hash[String, Data]`
 
 Default value: `{}`
 
-##### <a name="-k8s--node--kubelet--runtime"></a>`runtime`
+##### <a name="-k8s--node--kubelet--auth"></a>`auth`
 
-Data type: `String`
+Data type: `K8s::Node_auth`
+
+type of node authentication
+
+Default value: `$k8s::node::node_auth`
+
+##### <a name="-k8s--node--kubelet--ca_cert"></a>`ca_cert`
+
+Data type: `Optional[Stdlib::Unixpath]`
+
+path to the ca cert
+
+Default value: `$k8s::node::ca_cert`
+
+##### <a name="-k8s--node--kubelet--cert"></a>`cert`
+
+Data type: `Optional[Stdlib::Unixpath]`
+
+path to node cert file
+
+Default value: `$k8s::node::node_cert`
+
+##### <a name="-k8s--node--kubelet--cert_path"></a>`cert_path`
+
+Data type: `Stdlib::Unixpath`
+
+path to cert files
+
+Default value: `$k8s::node::cert_path`
+
+##### <a name="-k8s--node--kubelet--config"></a>`config`
+
+Data type: `Hash[String, Data]`
 
 
 
-Default value: `$k8s::container_manager`
+Default value: `{}`
 
-##### <a name="-k8s--node--kubelet--runtime_service"></a>`runtime_service`
+##### <a name="-k8s--node--kubelet--ensure"></a>`ensure`
 
-Data type: `String`
+Data type: `K8s::Ensure`
 
+set ensure for installation or deinstallation
 
+Default value: `$k8s::node::ensure`
 
-Default value: `$k8s::container_runtime_service`
+##### <a name="-k8s--node--kubelet--firewall_type"></a>`firewall_type`
+
+Data type: `K8s::Firewall`
+
+define the type of firewall to use
+
+Default value: `$k8s::node::firewall_type`
+
+##### <a name="-k8s--node--kubelet--key"></a>`key`
+
+Data type: `Optional[Stdlib::Unixpath]`
+
+path to node key file
+
+Default value: `$k8s::node::node_key`
+
+##### <a name="-k8s--node--kubelet--kubeconfig"></a>`kubeconfig`
+
+Data type: `Stdlib::Unixpath`
+
+path to kubeconfig
+
+Default value: `'/srv/kubernetes/kubelet.kubeconf'`
+
+##### <a name="-k8s--node--kubelet--manage_firewall"></a>`manage_firewall`
+
+Data type: `Boolean`
+
+whether to manage firewall or not
+
+Default value: `$k8s::node::manage_firewall`
+
+##### <a name="-k8s--node--kubelet--manage_kernel_modules"></a>`manage_kernel_modules`
+
+Data type: `Boolean`
+
+whether to load kernel modules or not
+
+Default value: `$k8s::node::manage_kernel_modules`
+
+##### <a name="-k8s--node--kubelet--manage_sysctl_settings"></a>`manage_sysctl_settings`
+
+Data type: `Boolean`
+
+whether to manage sysctl settings or not
+
+Default value: `$k8s::node::manage_sysctl_settings`
+
+##### <a name="-k8s--node--kubelet--master"></a>`master`
+
+Data type: `Stdlib::HTTPUrl`
+
+cluster API connection
+
+Default value: `$k8s::node::master`
 
 ##### <a name="-k8s--node--kubelet--puppetdb_discovery_tag"></a>`puppetdb_discovery_tag`
 
 Data type: `String[1]`
 
-
+enable puppetdb resource searching
 
 Default value: `$k8s::node::puppetdb_discovery_tag`
-
-##### <a name="-k8s--node--kubelet--auth"></a>`auth`
-
-Data type: `K8s::Node_auth`
-
-
-
-Default value: `$k8s::node::node_auth`
 
 ##### <a name="-k8s--node--kubelet--rotate_server_tls"></a>`rotate_server_tls`
 
@@ -866,29 +922,21 @@ Data type: `Boolean`
 
 Default value: `$auth == 'bootstrap'`
 
-##### <a name="-k8s--node--kubelet--manage_firewall"></a>`manage_firewall`
+##### <a name="-k8s--node--kubelet--runtime"></a>`runtime`
 
-Data type: `Boolean`
+Data type: `String`
 
+which container runtime to use
 
+Default value: `$k8s::container_manager`
 
-Default value: `$k8s::node::manage_firewall`
+##### <a name="-k8s--node--kubelet--runtime_service"></a>`runtime_service`
 
-##### <a name="-k8s--node--kubelet--manage_kernel_modules"></a>`manage_kernel_modules`
+Data type: `String`
 
-Data type: `Boolean`
+name of the service of the container runtime
 
-
-
-Default value: `$k8s::node::manage_kernel_modules`
-
-##### <a name="-k8s--node--kubelet--manage_sysctl_settings"></a>`manage_sysctl_settings`
-
-Data type: `Boolean`
-
-
-
-Default value: `$k8s::node::manage_sysctl_settings`
+Default value: `$k8s::container_runtime_service`
 
 ##### <a name="-k8s--node--kubelet--support_dualstack"></a>`support_dualstack`
 
@@ -898,61 +946,13 @@ Data type: `Boolean`
 
 Default value: `$k8s::cluster_cidr =~ Array[Data, 2]`
 
-##### <a name="-k8s--node--kubelet--cert_path"></a>`cert_path`
-
-Data type: `Stdlib::Unixpath`
-
-
-
-Default value: `$k8s::node::cert_path`
-
-##### <a name="-k8s--node--kubelet--kubeconfig"></a>`kubeconfig`
-
-Data type: `Stdlib::Unixpath`
-
-
-
-Default value: `'/srv/kubernetes/kubelet.kubeconf'`
-
-##### <a name="-k8s--node--kubelet--ca_cert"></a>`ca_cert`
-
-Data type: `Optional[Stdlib::Unixpath]`
-
-
-
-Default value: `$k8s::node::ca_cert`
-
-##### <a name="-k8s--node--kubelet--cert"></a>`cert`
-
-Data type: `Optional[Stdlib::Unixpath]`
-
-
-
-Default value: `$k8s::node::node_cert`
-
-##### <a name="-k8s--node--kubelet--key"></a>`key`
-
-Data type: `Optional[Stdlib::Unixpath]`
-
-
-
-Default value: `$k8s::node::node_key`
-
 ##### <a name="-k8s--node--kubelet--token"></a>`token`
 
 Data type: `Optional[String[1]]`
 
-
+k8s token to join a cluster
 
 Default value: `$k8s::node::node_token`
-
-##### <a name="-k8s--node--kubelet--firewall_type"></a>`firewall_type`
-
-Data type: `K8s::Firewall`
-
-
-
-Default value: `$k8s::node::firewall_type`
 
 ### <a name="k8s--repo"></a>`k8s::repo`
 
@@ -1214,101 +1214,37 @@ Installs and configures a Kubernetes apiserver
 
 The following parameters are available in the `k8s::server::apiserver` class:
 
-* [`ensure`](#-k8s--server--apiserver--ensure)
-* [`arguments`](#-k8s--server--apiserver--arguments)
-* [`service_cluster_cidr`](#-k8s--server--apiserver--service_cluster_cidr)
-* [`etcd_servers`](#-k8s--server--apiserver--etcd_servers)
-* [`discover_etcd_servers`](#-k8s--server--apiserver--discover_etcd_servers)
-* [`manage_firewall`](#-k8s--server--apiserver--manage_firewall)
-* [`puppetdb_discovery_tag`](#-k8s--server--apiserver--puppetdb_discovery_tag)
-* [`cert_path`](#-k8s--server--apiserver--cert_path)
-* [`ca_cert`](#-k8s--server--apiserver--ca_cert)
+* [`advertise_address`](#-k8s--server--apiserver--advertise_address)
 * [`aggregator_ca_cert`](#-k8s--server--apiserver--aggregator_ca_cert)
-* [`serviceaccount_public`](#-k8s--server--apiserver--serviceaccount_public)
-* [`serviceaccount_private`](#-k8s--server--apiserver--serviceaccount_private)
 * [`apiserver_cert`](#-k8s--server--apiserver--apiserver_cert)
-* [`apiserver_key`](#-k8s--server--apiserver--apiserver_key)
-* [`front_proxy_cert`](#-k8s--server--apiserver--front_proxy_cert)
-* [`front_proxy_key`](#-k8s--server--apiserver--front_proxy_key)
 * [`apiserver_client_cert`](#-k8s--server--apiserver--apiserver_client_cert)
 * [`apiserver_client_key`](#-k8s--server--apiserver--apiserver_client_key)
+* [`apiserver_key`](#-k8s--server--apiserver--apiserver_key)
+* [`arguments`](#-k8s--server--apiserver--arguments)
+* [`ca_cert`](#-k8s--server--apiserver--ca_cert)
+* [`cert_path`](#-k8s--server--apiserver--cert_path)
+* [`discover_etcd_servers`](#-k8s--server--apiserver--discover_etcd_servers)
+* [`ensure`](#-k8s--server--apiserver--ensure)
 * [`etcd_ca`](#-k8s--server--apiserver--etcd_ca)
 * [`etcd_cert`](#-k8s--server--apiserver--etcd_cert)
 * [`etcd_key`](#-k8s--server--apiserver--etcd_key)
-* [`advertise_address`](#-k8s--server--apiserver--advertise_address)
+* [`etcd_servers`](#-k8s--server--apiserver--etcd_servers)
 * [`firewall_type`](#-k8s--server--apiserver--firewall_type)
+* [`front_proxy_cert`](#-k8s--server--apiserver--front_proxy_cert)
+* [`front_proxy_key`](#-k8s--server--apiserver--front_proxy_key)
+* [`manage_firewall`](#-k8s--server--apiserver--manage_firewall)
+* [`puppetdb_discovery_tag`](#-k8s--server--apiserver--puppetdb_discovery_tag)
+* [`service_cluster_cidr`](#-k8s--server--apiserver--service_cluster_cidr)
+* [`serviceaccount_private`](#-k8s--server--apiserver--serviceaccount_private)
+* [`serviceaccount_public`](#-k8s--server--apiserver--serviceaccount_public)
 
-##### <a name="-k8s--server--apiserver--ensure"></a>`ensure`
+##### <a name="-k8s--server--apiserver--advertise_address"></a>`advertise_address`
 
-Data type: `K8s::Ensure`
+Data type: `Stdlib::IP::Address::Nosubnet`
 
+bind address of the apiserver
 
-
-Default value: `$k8s::server::ensure`
-
-##### <a name="-k8s--server--apiserver--arguments"></a>`arguments`
-
-Data type: `Hash[String, Data]`
-
-
-
-Default value: `{}`
-
-##### <a name="-k8s--server--apiserver--service_cluster_cidr"></a>`service_cluster_cidr`
-
-Data type: `K8s::CIDR`
-
-
-
-Default value: `$k8s::service_cluster_cidr`
-
-##### <a name="-k8s--server--apiserver--etcd_servers"></a>`etcd_servers`
-
-Data type: `Optional[Array[Stdlib::HTTPUrl]]`
-
-
-
-Default value: `$k8s::server::etcd_servers`
-
-##### <a name="-k8s--server--apiserver--discover_etcd_servers"></a>`discover_etcd_servers`
-
-Data type: `Boolean`
-
-
-
-Default value: `$k8s::puppetdb_discovery`
-
-##### <a name="-k8s--server--apiserver--manage_firewall"></a>`manage_firewall`
-
-Data type: `Boolean`
-
-
-
-Default value: `$k8s::server::manage_firewall`
-
-##### <a name="-k8s--server--apiserver--puppetdb_discovery_tag"></a>`puppetdb_discovery_tag`
-
-Data type: `String`
-
-
-
-Default value: `$k8s::server::puppetdb_discovery_tag`
-
-##### <a name="-k8s--server--apiserver--cert_path"></a>`cert_path`
-
-Data type: `Stdlib::Unixpath`
-
-
-
-Default value: `$k8s::server::tls::cert_path`
-
-##### <a name="-k8s--server--apiserver--ca_cert"></a>`ca_cert`
-
-Data type: `Stdlib::Unixpath`
-
-
-
-Default value: `$k8s::server::tls::ca_cert`
+Default value: `fact('networking.ip')`
 
 ##### <a name="-k8s--server--apiserver--aggregator_ca_cert"></a>`aggregator_ca_cert`
 
@@ -1318,37 +1254,117 @@ Data type: `Stdlib::Unixpath`
 
 Default value: `$k8s::server::tls::aggregator_ca_cert`
 
-##### <a name="-k8s--server--apiserver--serviceaccount_public"></a>`serviceaccount_public`
-
-Data type: `Stdlib::Unixpath`
-
-
-
-Default value: `"${cert_path}/service-account.pub"`
-
-##### <a name="-k8s--server--apiserver--serviceaccount_private"></a>`serviceaccount_private`
-
-Data type: `Stdlib::Unixpath`
-
-
-
-Default value: `"${cert_path}/service-account.key"`
-
 ##### <a name="-k8s--server--apiserver--apiserver_cert"></a>`apiserver_cert`
 
 Data type: `Stdlib::Unixpath`
 
-
+path to the apiserver cert file
 
 Default value: `"${cert_path}/kube-apiserver.pem"`
+
+##### <a name="-k8s--server--apiserver--apiserver_client_cert"></a>`apiserver_client_cert`
+
+Data type: `Stdlib::Unixpath`
+
+path to the apiserver client cert file
+
+Default value: `"${cert_path}/apiserver-kubelet-client.pem"`
+
+##### <a name="-k8s--server--apiserver--apiserver_client_key"></a>`apiserver_client_key`
+
+Data type: `Stdlib::Unixpath`
+
+path to the apiserver client key file
+
+Default value: `"${cert_path}/apiserver-kubelet-client.key"`
 
 ##### <a name="-k8s--server--apiserver--apiserver_key"></a>`apiserver_key`
 
 Data type: `Stdlib::Unixpath`
 
-
+path to the apiserver cert file
 
 Default value: `"${cert_path}/kube-apiserver.key"`
+
+##### <a name="-k8s--server--apiserver--arguments"></a>`arguments`
+
+Data type: `Hash[String, Data]`
+
+
+
+Default value: `{}`
+
+##### <a name="-k8s--server--apiserver--ca_cert"></a>`ca_cert`
+
+Data type: `Stdlib::Unixpath`
+
+path to the ca cert
+
+Default value: `$k8s::server::tls::ca_cert`
+
+##### <a name="-k8s--server--apiserver--cert_path"></a>`cert_path`
+
+Data type: `Stdlib::Unixpath`
+
+path to cert files
+
+Default value: `$k8s::server::tls::cert_path`
+
+##### <a name="-k8s--server--apiserver--discover_etcd_servers"></a>`discover_etcd_servers`
+
+Data type: `Boolean`
+
+enable puppetdb resource searching
+
+Default value: `$k8s::puppetdb_discovery`
+
+##### <a name="-k8s--server--apiserver--ensure"></a>`ensure`
+
+Data type: `K8s::Ensure`
+
+set ensure for installation or deinstallation
+
+Default value: `$k8s::server::ensure`
+
+##### <a name="-k8s--server--apiserver--etcd_ca"></a>`etcd_ca`
+
+Data type: `Stdlib::Unixpath`
+
+path to the etcd ca cert file
+
+Default value: `"${cert_path}/etcd-ca.pem"`
+
+##### <a name="-k8s--server--apiserver--etcd_cert"></a>`etcd_cert`
+
+Data type: `Stdlib::Unixpath`
+
+path to the etcd cert file
+
+Default value: `"${cert_path}/etcd.pem"`
+
+##### <a name="-k8s--server--apiserver--etcd_key"></a>`etcd_key`
+
+Data type: `Stdlib::Unixpath`
+
+path to the etcd key file
+
+Default value: `"${cert_path}/etcd.key"`
+
+##### <a name="-k8s--server--apiserver--etcd_servers"></a>`etcd_servers`
+
+Data type: `Optional[Array[Stdlib::HTTPUrl]]`
+
+list etcd servers if no puppetdb is used
+
+Default value: `$k8s::server::etcd_servers`
+
+##### <a name="-k8s--server--apiserver--firewall_type"></a>`firewall_type`
+
+Data type: `K8s::Firewall`
+
+define the type of firewall to use
+
+Default value: `$k8s::server::firewall_type`
 
 ##### <a name="-k8s--server--apiserver--front_proxy_cert"></a>`front_proxy_cert`
 
@@ -1366,61 +1382,45 @@ Data type: `Stdlib::Unixpath`
 
 Default value: `"${cert_path}/front-proxy-client.key"`
 
-##### <a name="-k8s--server--apiserver--apiserver_client_cert"></a>`apiserver_client_cert`
+##### <a name="-k8s--server--apiserver--manage_firewall"></a>`manage_firewall`
+
+Data type: `Boolean`
+
+whether to manage firewall or not
+
+Default value: `$k8s::server::manage_firewall`
+
+##### <a name="-k8s--server--apiserver--puppetdb_discovery_tag"></a>`puppetdb_discovery_tag`
+
+Data type: `String`
+
+enable puppetdb resource searching
+
+Default value: `$k8s::server::puppetdb_discovery_tag`
+
+##### <a name="-k8s--server--apiserver--service_cluster_cidr"></a>`service_cluster_cidr`
+
+Data type: `K8s::CIDR`
+
+
+
+Default value: `$k8s::service_cluster_cidr`
+
+##### <a name="-k8s--server--apiserver--serviceaccount_private"></a>`serviceaccount_private`
 
 Data type: `Stdlib::Unixpath`
 
 
 
-Default value: `"${cert_path}/apiserver-kubelet-client.pem"`
+Default value: `"${cert_path}/service-account.key"`
 
-##### <a name="-k8s--server--apiserver--apiserver_client_key"></a>`apiserver_client_key`
-
-Data type: `Stdlib::Unixpath`
-
-
-
-Default value: `"${cert_path}/apiserver-kubelet-client.key"`
-
-##### <a name="-k8s--server--apiserver--etcd_ca"></a>`etcd_ca`
+##### <a name="-k8s--server--apiserver--serviceaccount_public"></a>`serviceaccount_public`
 
 Data type: `Stdlib::Unixpath`
 
 
 
-Default value: `"${cert_path}/etcd-ca.pem"`
-
-##### <a name="-k8s--server--apiserver--etcd_cert"></a>`etcd_cert`
-
-Data type: `Stdlib::Unixpath`
-
-
-
-Default value: `"${cert_path}/etcd.pem"`
-
-##### <a name="-k8s--server--apiserver--etcd_key"></a>`etcd_key`
-
-Data type: `Stdlib::Unixpath`
-
-
-
-Default value: `"${cert_path}/etcd.key"`
-
-##### <a name="-k8s--server--apiserver--advertise_address"></a>`advertise_address`
-
-Data type: `Stdlib::IP::Address::Nosubnet`
-
-
-
-Default value: `fact('networking.ip')`
-
-##### <a name="-k8s--server--apiserver--firewall_type"></a>`firewall_type`
-
-Data type: `K8s::Firewall`
-
-
-
-Default value: `$k8s::server::firewall_type`
+Default value: `"${cert_path}/service-account.pub"`
 
 ### <a name="k8s--server--controller_manager"></a>`k8s::server::controller_manager`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -417,11 +417,11 @@ Default value: `'none'`
 
 ##### <a name="-k8s--firewall_type"></a>`firewall_type`
 
-Data type: `K8s::Firewall`
+Data type: `Optional[K8s::Firewall]`
 
 
 
-Default value: `'firewalld'`
+Default value: `undef`
 
 ### <a name="k8s--install--kubeadm"></a>`k8s::install::kubeadm`
 
@@ -513,7 +513,7 @@ Default value: `$k8s::ensure`
 
 ##### <a name="-k8s--node--firewall_type"></a>`firewall_type`
 
-Data type: `K8s::Firewall`
+Data type: `Optional[K8s::Firewall]`
 
 define the type of firewall to use
 
@@ -852,7 +852,7 @@ Default value: `$k8s::node::ensure`
 
 ##### <a name="-k8s--node--kubelet--firewall_type"></a>`firewall_type`
 
-Data type: `K8s::Firewall`
+Data type: `Optional[K8s::Firewall]`
 
 define the type of firewall to use
 
@@ -1360,7 +1360,7 @@ Default value: `$k8s::server::etcd_servers`
 
 ##### <a name="-k8s--server--apiserver--firewall_type"></a>`firewall_type`
 
-Data type: `K8s::Firewall`
+Data type: `Optional[K8s::Firewall]`
 
 define the type of firewall to use
 
@@ -1668,7 +1668,7 @@ Default value: `"${cert_path}/client-ca.pem"`
 
 ##### <a name="-k8s--server--etcd--firewall_type"></a>`firewall_type`
 
-Data type: `K8s::Firewall`
+Data type: `Optional[K8s::Firewall]`
 
 
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -903,7 +903,7 @@ The following parameters are available in the `k8s::repo` class:
 
 Data type: `Boolean`
 
-
+wether to add cri-o repository or not
 
 Default value: `$k8s::manage_container_manager`
 
@@ -911,7 +911,7 @@ Default value: `$k8s::manage_container_manager`
 
 Data type: `String[1]`
 
-
+version o cri-o
 
 Default value: `$k8s::version.split('\.')[0, 2].join('.')`
 
@@ -923,116 +923,28 @@ Sets up a Kubernetes server instance
 
 The following parameters are available in the `k8s::server` class:
 
-* [`ensure`](#-k8s--server--ensure)
+* [`aggregator_ca_cert`](#-k8s--server--aggregator_ca_cert)
+* [`aggregator_ca_key`](#-k8s--server--aggregator_ca_key)
 * [`api_port`](#-k8s--server--api_port)
+* [`ca_cert`](#-k8s--server--ca_cert)
+* [`ca_key`](#-k8s--server--ca_key)
+* [`cert_path`](#-k8s--server--cert_path)
 * [`cluster_cidr`](#-k8s--server--cluster_cidr)
-* [`dns_service_address`](#-k8s--server--dns_service_address)
 * [`cluster_domain`](#-k8s--server--cluster_domain)
 * [`direct_master`](#-k8s--server--direct_master)
-* [`master`](#-k8s--server--master)
-* [`cert_path`](#-k8s--server--cert_path)
-* [`ca_key`](#-k8s--server--ca_key)
-* [`ca_cert`](#-k8s--server--ca_cert)
-* [`aggregator_ca_key`](#-k8s--server--aggregator_ca_key)
-* [`aggregator_ca_cert`](#-k8s--server--aggregator_ca_cert)
+* [`dns_service_address`](#-k8s--server--dns_service_address)
+* [`ensure`](#-k8s--server--ensure)
+* [`etcd_servers`](#-k8s--server--etcd_servers)
 * [`generate_ca`](#-k8s--server--generate_ca)
+* [`manage_certs`](#-k8s--server--manage_certs)
+* [`manage_components`](#-k8s--server--manage_components)
 * [`manage_etcd`](#-k8s--server--manage_etcd)
 * [`manage_firewall`](#-k8s--server--manage_firewall)
-* [`manage_certs`](#-k8s--server--manage_certs)
-* [`manage_signing`](#-k8s--server--manage_signing)
-* [`manage_components`](#-k8s--server--manage_components)
 * [`manage_resources`](#-k8s--server--manage_resources)
+* [`manage_signing`](#-k8s--server--manage_signing)
+* [`master`](#-k8s--server--master)
 * [`node_on_server`](#-k8s--server--node_on_server)
 * [`puppetdb_discovery_tag`](#-k8s--server--puppetdb_discovery_tag)
-* [`etcd_servers`](#-k8s--server--etcd_servers)
-
-##### <a name="-k8s--server--ensure"></a>`ensure`
-
-Data type: `K8s::Ensure`
-
-
-
-Default value: `$k8s::ensure`
-
-##### <a name="-k8s--server--api_port"></a>`api_port`
-
-Data type: `Integer[1]`
-
-
-
-Default value: `6443`
-
-##### <a name="-k8s--server--cluster_cidr"></a>`cluster_cidr`
-
-Data type: `K8s::CIDR`
-
-
-
-Default value: `$k8s::cluster_cidr`
-
-##### <a name="-k8s--server--dns_service_address"></a>`dns_service_address`
-
-Data type: `K8s::IP_addresses`
-
-
-
-Default value: `$k8s::dns_service_address`
-
-##### <a name="-k8s--server--cluster_domain"></a>`cluster_domain`
-
-Data type: `String`
-
-
-
-Default value: `$k8s::cluster_domain`
-
-##### <a name="-k8s--server--direct_master"></a>`direct_master`
-
-Data type: `String`
-
-
-
-Default value: `"https://${fact('networking.ip')}:${api_port}"`
-
-##### <a name="-k8s--server--master"></a>`master`
-
-Data type: `String`
-
-
-
-Default value: `$k8s::master`
-
-##### <a name="-k8s--server--cert_path"></a>`cert_path`
-
-Data type: `Stdlib::Unixpath`
-
-
-
-Default value: `'/etc/kubernetes/certs'`
-
-##### <a name="-k8s--server--ca_key"></a>`ca_key`
-
-Data type: `Stdlib::Unixpath`
-
-
-
-Default value: `"${cert_path}/ca.key"`
-
-##### <a name="-k8s--server--ca_cert"></a>`ca_cert`
-
-Data type: `Stdlib::Unixpath`
-
-
-
-Default value: `"${cert_path}/ca.pem"`
-
-##### <a name="-k8s--server--aggregator_ca_key"></a>`aggregator_ca_key`
-
-Data type: `Stdlib::Unixpath`
-
-
-
-Default value: `"${cert_path}/aggregator-ca.key"`
 
 ##### <a name="-k8s--server--aggregator_ca_cert"></a>`aggregator_ca_cert`
 
@@ -1042,19 +954,123 @@ Data type: `Stdlib::Unixpath`
 
 Default value: `"${cert_path}/aggregator-ca.pem"`
 
+##### <a name="-k8s--server--aggregator_ca_key"></a>`aggregator_ca_key`
+
+Data type: `Stdlib::Unixpath`
+
+
+
+Default value: `"${cert_path}/aggregator-ca.key"`
+
+##### <a name="-k8s--server--api_port"></a>`api_port`
+
+Data type: `Integer[1]`
+
+Cluster API port
+
+Default value: `6443`
+
+##### <a name="-k8s--server--ca_cert"></a>`ca_cert`
+
+Data type: `Stdlib::Unixpath`
+
+path to the ca cert
+
+Default value: `"${cert_path}/ca.pem"`
+
+##### <a name="-k8s--server--ca_key"></a>`ca_key`
+
+Data type: `Stdlib::Unixpath`
+
+path to the ca key
+
+Default value: `"${cert_path}/ca.key"`
+
+##### <a name="-k8s--server--cert_path"></a>`cert_path`
+
+Data type: `Stdlib::Unixpath`
+
+path to cert files
+
+Default value: `'/etc/kubernetes/certs'`
+
+##### <a name="-k8s--server--cluster_cidr"></a>`cluster_cidr`
+
+Data type: `K8s::CIDR`
+
+cluster cidr
+
+Default value: `$k8s::cluster_cidr`
+
+##### <a name="-k8s--server--cluster_domain"></a>`cluster_domain`
+
+Data type: `String`
+
+cluster domain name
+
+Default value: `$k8s::cluster_domain`
+
+##### <a name="-k8s--server--direct_master"></a>`direct_master`
+
+Data type: `String`
+
+direct clust API connection
+
+Default value: `"https://${fact('networking.ip')}:${api_port}"`
+
+##### <a name="-k8s--server--dns_service_address"></a>`dns_service_address`
+
+Data type: `K8s::IP_addresses`
+
+cluster dns service address
+
+Default value: `$k8s::dns_service_address`
+
+##### <a name="-k8s--server--ensure"></a>`ensure`
+
+Data type: `K8s::Ensure`
+
+
+
+Default value: `$k8s::ensure`
+
+##### <a name="-k8s--server--etcd_servers"></a>`etcd_servers`
+
+Data type: `Optional[Array[Stdlib::HTTPUrl]]`
+
+list etcd servers if no puppetdb is used
+
+Default value: `undef`
+
 ##### <a name="-k8s--server--generate_ca"></a>`generate_ca`
 
 Data type: `Boolean`
 
-
+initially generate ca
 
 Default value: `false`
+
+##### <a name="-k8s--server--manage_certs"></a>`manage_certs`
+
+Data type: `Boolean`
+
+wether to manage certs or not
+
+Default value: `true`
+
+##### <a name="-k8s--server--manage_components"></a>`manage_components`
+
+Data type: `Boolean`
+
+wether to manage components or not
+
+Default value: `true`
 
 ##### <a name="-k8s--server--manage_etcd"></a>`manage_etcd`
 
 Data type: `Boolean`
 
-
+wether to manage etcd or not
 
 Default value: `$k8s::manage_etcd`
 
@@ -1062,15 +1078,15 @@ Default value: `$k8s::manage_etcd`
 
 Data type: `Boolean`
 
-
+wether to manage firewall or not
 
 Default value: `$k8s::manage_firewall`
 
-##### <a name="-k8s--server--manage_certs"></a>`manage_certs`
+##### <a name="-k8s--server--manage_resources"></a>`manage_resources`
 
 Data type: `Boolean`
 
-
+wether to manage cluster internal resources or not
 
 Default value: `true`
 
@@ -1078,31 +1094,23 @@ Default value: `true`
 
 Data type: `Boolean`
 
-
+wether to manage cert signing or not
 
 Default value: `$k8s::puppetdb_discovery`
 
-##### <a name="-k8s--server--manage_components"></a>`manage_components`
+##### <a name="-k8s--server--master"></a>`master`
 
-Data type: `Boolean`
+Data type: `String`
 
+cluster API connection
 
-
-Default value: `true`
-
-##### <a name="-k8s--server--manage_resources"></a>`manage_resources`
-
-Data type: `Boolean`
-
-
-
-Default value: `true`
+Default value: `$k8s::master`
 
 ##### <a name="-k8s--server--node_on_server"></a>`node_on_server`
 
 Data type: `Boolean`
 
-
+wether to use controller also as nodes or not
 
 Default value: `true`
 
@@ -1110,17 +1118,9 @@ Default value: `true`
 
 Data type: `String[1]`
 
-
+enable puppetdb resource searching
 
 Default value: `$k8s::puppetdb_discovery_tag`
-
-##### <a name="-k8s--server--etcd_servers"></a>`etcd_servers`
-
-Data type: `Optional[Array[Stdlib::HTTPUrl]]`
-
-
-
-Default value: `undef`
 
 ### <a name="k8s--server--apiserver"></a>`k8s::server::apiserver`
 
@@ -1151,6 +1151,7 @@ The following parameters are available in the `k8s::server::apiserver` class:
 * [`etcd_ca`](#-k8s--server--apiserver--etcd_ca)
 * [`etcd_cert`](#-k8s--server--apiserver--etcd_cert)
 * [`etcd_key`](#-k8s--server--apiserver--etcd_key)
+* [`advertise_address`](#-k8s--server--apiserver--advertise_address)
 
 ##### <a name="-k8s--server--apiserver--ensure"></a>`ensure`
 
@@ -1319,6 +1320,14 @@ Data type: `Stdlib::Unixpath`
 
 
 Default value: `"${cert_path}/etcd.key"`
+
+##### <a name="-k8s--server--apiserver--advertise_address"></a>`advertise_address`
+
+Data type: `Stdlib::IP::Address::Nosubnet`
+
+
+
+Default value: `fact('networking.ip')`
 
 ### <a name="k8s--server--controller_manager"></a>`k8s::server::controller_manager`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1112,7 +1112,7 @@ Default value: `undef`
 
 ##### <a name="-k8s--server--firewall_type"></a>`firewall_type`
 
-Data type: `K8s::Firewall`
+Data type: `Optional[K8s::Firewall]`
 
 define the type of firewall to use
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,6 +52,7 @@ class k8s (
   Stdlib::Fqdn $cluster_domain                       = 'cluster.local',
 
   Enum['node','server','none']  $role = 'none',
+  K8s::Firewall $firewall_type = 'firewalld',
 ) {
   if $manage_container_manager {
     if $container_manager == 'docker' {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,5 @@
 # @summary Sets up a Kubernetes instance - either as a node or as a server
-# 
+#
 # @param manage_kernel_modules
 #   A flag to manage required Kernel modules.
 #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,7 +52,7 @@ class k8s (
   Stdlib::Fqdn $cluster_domain                       = 'cluster.local',
 
   Enum['node','server','none']  $role = 'none',
-  K8s::Firewall $firewall_type = 'firewalld',
+  Optional[K8s::Firewall] $firewall_type = undef,
 ) {
   if $manage_container_manager {
     if $container_manager == 'docker' {

--- a/manifests/install/kubeadm.pp
+++ b/manifests/install/kubeadm.pp
@@ -2,7 +2,7 @@
 #
 # @param ensure
 #
-class k8s::server::kubeadm (
+class k8s::install::kubeadm (
   K8s::Ensure $ensure = $k8s::ensure,
 ) {
   k8s::binary { 'kubeadm':

--- a/manifests/install/kubeadm.pp
+++ b/manifests/install/kubeadm.pp
@@ -1,6 +1,6 @@
 # @summary Installs the kubeadm binary
 #
-# @param ensure
+# @param ensure set ensure for installation or deinstallation
 #
 class k8s::install::kubeadm (
   K8s::Ensure $ensure = $k8s::ensure,

--- a/manifests/install/kubectl.pp
+++ b/manifests/install/kubectl.pp
@@ -1,6 +1,6 @@
 # @summary Installs the kubectl binary
 #
-# @param ensure
+# @param ensure set ensure for installation or deinstallation
 #
 class k8s::install::kubectl (
   K8s::Ensure $ensure = $k8s::ensure,

--- a/manifests/install/kubectl.pp
+++ b/manifests/install/kubectl.pp
@@ -1,0 +1,11 @@
+# @summary Installs the kubectl binary
+#
+# @param ensure
+#
+class k8s::install::kubectl (
+  K8s::Ensure $ensure = $k8s::ensure,
+) {
+  k8s::binary { 'kubectl':
+    ensure => $ensure,
+  }
+}

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -26,6 +26,8 @@ class k8s::node (
   # For token and bootstrap auth
   Optional[String[1]] $node_token  = undef,
   Optional[String[1]] $proxy_token = undef,
+
+  K8s::Firewall $firewall_type = $k8s::firewall_type,
 ) {
   if $manage_kubelet {
     include k8s::node::kubelet

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -1,4 +1,25 @@
 # @summary Installs a Kubernetes node
+#
+# @param ca_cert path to the ca cert
+# @param cert_path path to cert files
+# @param ensure set ensure for installation or deinstallation
+# @param firewall_type define the type of firewall to use
+# @param manage_firewall whether to manage firewall or not
+# @param manage_kernel_modules whether to load kernel modules or not
+# @param manage_kubelet whether to manage kublet or not
+# @param manage_proxy whether to manage kube-proxy or not
+# @param manage_sysctl_settings whether to manage sysctl settings or not
+# @param master cluster API connection
+# @param node_auth type of node authentication
+# @param node_cert path to node cert file
+# @param node_key path to node key file
+# @param node_token k8s token to join a cluster
+# @param proxy_auth which proxy auth to use
+# @param proxy_cert path to proxy cert file
+# @param proxy_key path to proxy key file
+# @param proxy_token k8s token for kube-proxy
+# @param puppetdb_discovery_tag enable puppetdb resource searching
+#
 class k8s::node (
   K8s::Ensure $ensure = $k8s::ensure,
 

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -48,7 +48,7 @@ class k8s::node (
   Optional[String[1]] $node_token  = undef,
   Optional[String[1]] $proxy_token = undef,
 
-  K8s::Firewall $firewall_type = $k8s::firewall_type,
+  Optional[K8s::Firewall] $firewall_type = $k8s::firewall_type,
 ) {
   if $manage_kubelet {
     include k8s::node::kubelet

--- a/manifests/node/kubelet.pp
+++ b/manifests/node/kubelet.pp
@@ -160,6 +160,14 @@ class k8s::node::kubelet (
       'net.ipv4.ip_forward':;
       'net.ipv6.conf.all.forwarding':;
     }
+
+    if $manage_kernel_modules {
+      Kmod::Load['br_netfilter']
+      -> [
+        Sysctl['net.bridge.bridge-nf-call-iptables'],
+        Sysctl['net.bridge.bridge-nf-call-ip6tables']
+      ]
+    }
   }
 
   file { '/etc/kubernetes/kubelet.conf':

--- a/manifests/node/kubelet.pp
+++ b/manifests/node/kubelet.pp
@@ -1,4 +1,26 @@
 # @summary Installs and configures kubelet
+#
+# @param arguments
+# @param auth type of node authentication
+# @param ca_cert path to the ca cert
+# @param cert path to node cert file
+# @param cert_path path to cert files
+# @param config
+# @param ensure set ensure for installation or deinstallation
+# @param firewall_type define the type of firewall to use
+# @param key path to node key file
+# @param kubeconfig path to kubeconfig
+# @param manage_firewall whether to manage firewall or not
+# @param manage_kernel_modules whether to load kernel modules or not
+# @param manage_sysctl_settings whether to manage sysctl settings or not
+# @param master cluster API connection
+# @param puppetdb_discovery_tag enable puppetdb resource searching
+# @param rotate_server_tls
+# @param runtime which container runtime to use
+# @param runtime_service name of the service of the container runtime
+# @param support_dualstack
+# @param token k8s token to join a cluster
+#
 class k8s::node::kubelet (
   K8s::Ensure $ensure = $k8s::node::ensure,
 

--- a/manifests/node/kubelet.pp
+++ b/manifests/node/kubelet.pp
@@ -238,6 +238,8 @@ class k8s::node::kubelet (
   if $manage_firewall {
     case fact('os.family') {
       'Debian': {
+        include firewall
+
         firewall { '100 allow kubelet access':
           dport  => 10250,
           proto  => 'tcp',

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,4 +1,8 @@
 # @summary Handles repositories for the container runtime
+#
+# @param manage_container_manager wether to add cri-o repository or not
+# @param crio_version version o cri-o
+#
 class k8s::repo (
   Boolean $manage_container_manager = $k8s::manage_container_manager,
   String[1] $crio_version           = $k8s::version.split('\.')[0, 2].join('.'),

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,6 +1,6 @@
 # @summary Handles repositories for the container runtime
 #
-# @param manage_container_manager wether to add cri-o repository or not
+# @param manage_container_manager whether to add cri-o repository or not
 # @param crio_version version o cri-o
 #
 class k8s::repo (

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,4 +1,28 @@
 # @summary Sets up a Kubernetes server instance
+#
+# @param aggregator_ca_cert
+# @param aggregator_ca_key
+# @param api_port Cluster API port
+# @param ca_cert path to the ca cert
+# @param ca_key path to the ca key
+# @param cert_path path to cert files
+# @param cluster_cidr cluster cidr
+# @param cluster_domain cluster domain name
+# @param direct_master direct clust API connection
+# @param dns_service_address cluster dns service address
+# @param ensure
+# @param etcd_servers list etcd servers if no puppetdb is used
+# @param generate_ca initially generate ca
+# @param manage_certs wether to manage certs or not
+# @param manage_components wether to manage components or not
+# @param manage_etcd wether to manage etcd or not
+# @param manage_firewall wether to manage firewall or not
+# @param manage_resources wether to manage cluster internal resources or not
+# @param manage_signing wether to manage cert signing or not
+# @param master cluster API connection
+# @param node_on_server wether to use controller also as nodes or not
+# @param puppetdb_discovery_tag enable puppetdb resource searching
+#
 class k8s::server (
   K8s::Ensure $ensure  = $k8s::ensure,
   Integer[1] $api_port = 6443,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -99,6 +99,8 @@ class k8s::server (
   }
 
   include k8s::node::kubectl
+  include k8s::server::kubeadm
+
   kubeconfig { '/root/.kube/config':
     ensure          => $ensure,
     server          => "https://localhost:${api_port}",

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -10,13 +10,15 @@
 # @param cluster_domain cluster domain name
 # @param direct_master direct clust API connection
 # @param dns_service_address cluster dns service address
-# @param ensure
+# @param ensure set ensure for installation or deinstallation
 # @param etcd_servers list etcd servers if no puppetdb is used
+# @param firewall_type define the type of firewall to use
 # @param generate_ca initially generate ca
 # @param manage_certs whether to manage certs or not
 # @param manage_components whether to manage components or not
 # @param manage_etcd whether to manage etcd or not
 # @param manage_firewall whether to manage firewall or not
+# @param manage_kubeadm whether to install kubeadm or not
 # @param manage_resources whether to manage cluster internal resources or not
 # @param manage_signing whether to manage cert signing or not
 # @param master cluster API connection
@@ -47,9 +49,11 @@ class k8s::server (
   Boolean $manage_components        = true,
   Boolean $manage_resources         = true,
   Boolean $node_on_server           = true,
+  Boolean $manage_kubeadm           = false,
   String[1] $puppetdb_discovery_tag = $k8s::puppetdb_discovery_tag,
 
   Optional[Array[Stdlib::HTTPUrl]] $etcd_servers = undef,
+  K8s::Firewall $firewall_type = $k8s::firewall_type,
 ) {
   if $manage_etcd {
     class { 'k8s::server::etcd':
@@ -99,7 +103,10 @@ class k8s::server (
   }
 
   include k8s::install::kubectl
-  include k8s::install::kubeadm
+
+  if $manage_kubeadm {
+    include k8s::install::kubeadm
+  }
 
   kubeconfig { '/root/.kube/config':
     ensure          => $ensure,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -98,8 +98,8 @@ class k8s::server (
     $cluster_nodes.each |$node| { k8s::server::tls::k8s_sign { $node['certname']: } }
   }
 
-  include k8s::node::kubectl
-  include k8s::server::kubeadm
+  include k8s::install::kubectl
+  include k8s::install::kubeadm
 
   kubeconfig { '/root/.kube/config':
     ensure          => $ensure,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -53,7 +53,7 @@ class k8s::server (
   String[1] $puppetdb_discovery_tag = $k8s::puppetdb_discovery_tag,
 
   Optional[Array[Stdlib::HTTPUrl]] $etcd_servers = undef,
-  K8s::Firewall $firewall_type = $k8s::firewall_type,
+  Optional[K8s::Firewall] $firewall_type = $k8s::firewall_type,
 ) {
   if $manage_etcd {
     class { 'k8s::server::etcd':

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -13,14 +13,14 @@
 # @param ensure
 # @param etcd_servers list etcd servers if no puppetdb is used
 # @param generate_ca initially generate ca
-# @param manage_certs wether to manage certs or not
-# @param manage_components wether to manage components or not
-# @param manage_etcd wether to manage etcd or not
-# @param manage_firewall wether to manage firewall or not
-# @param manage_resources wether to manage cluster internal resources or not
-# @param manage_signing wether to manage cert signing or not
+# @param manage_certs whether to manage certs or not
+# @param manage_components whether to manage components or not
+# @param manage_etcd whether to manage etcd or not
+# @param manage_firewall whether to manage firewall or not
+# @param manage_resources whether to manage cluster internal resources or not
+# @param manage_signing whether to manage cert signing or not
 # @param master cluster API connection
-# @param node_on_server wether to use controller also as nodes or not
+# @param node_on_server whether to use controller also as nodes or not
 # @param puppetdb_discovery_tag enable puppetdb resource searching
 #
 class k8s::server (

--- a/manifests/server/apiserver.pp
+++ b/manifests/server/apiserver.pp
@@ -51,7 +51,7 @@ class k8s::server::apiserver (
   Stdlib::Unixpath $etcd_key               = "${cert_path}/etcd.key",
 
   Stdlib::IP::Address::Nosubnet $advertise_address = fact('networking.ip'),
-  K8s::Firewall $firewall_type                     = $k8s::server::firewall_type
+  Optional[K8s::Firewall] $firewall_type           = $k8s::server::firewall_type,
 ) {
   assert_private()
 
@@ -294,20 +294,30 @@ class k8s::server::apiserver (
   }
 
   if $manage_firewall {
-    if $facts['firewalld_version'] and $firewall_type == 'firewalld' {
-      firewalld_service { 'Allow k8s apiserver access':
-        ensure  => $ensure,
-        zone    => 'public',
-        service => 'kube-apiserver',
-      }
+    if $facts['firewalld_version'] {
+      $_firewall_type = pick($firewall_type, 'firewalld')
     } else {
-      include firewall
+      $_firewall_type = pick($firewall_type, 'iptables')
+    }
 
-      firewall { '100 allow k8s apiserver access':
-        dport  => 6443,
-        proto  => 'tcp',
-        action => 'accept',
+    case $_firewall_type {
+      'firewalld' : {
+        firewalld_service { 'Allow k8s apiserver access':
+          ensure  => $ensure,
+          zone    => 'public',
+          service => 'kube-apiserver',
+        }
       }
+      'iptables': {
+        include firewall
+
+        firewall { '100 allow k8s apiserver access':
+          dport  => 6443,
+          proto  => 'tcp',
+          action => 'accept',
+        }
+      }
+      default: {}
     }
   }
 }

--- a/manifests/server/apiserver.pp
+++ b/manifests/server/apiserver.pp
@@ -268,10 +268,22 @@ class k8s::server::apiserver (
   }
 
   if $manage_firewall {
-    firewalld_service { 'Allow k8s apiserver access':
-      ensure  => $ensure,
-      zone    => 'public',
-      service => 'kube-apiserver',
+    case fact('os.family') {
+      'Debian': {
+        firewall { '100 allow k8s apiserver access':
+          dport  => 6443,
+          proto  => 'tcp',
+          action => 'accept',
+        }
+      }
+      'RedHat': {
+        firewalld_service { 'Allow k8s apiserver access':
+          ensure  => $ensure,
+          zone    => 'public',
+          service => 'kube-apiserver',
+        }
+      }
+      default: {}
     }
   }
 }

--- a/manifests/server/apiserver.pp
+++ b/manifests/server/apiserver.pp
@@ -1,4 +1,29 @@
 # @summary Installs and configures a Kubernetes apiserver
+#
+# @param advertise_address bind address of the apiserver
+# @param aggregator_ca_cert
+# @param apiserver_cert path to the apiserver cert file
+# @param apiserver_client_cert path to the apiserver client cert file
+# @param apiserver_client_key path to the apiserver client key file
+# @param apiserver_key path to the apiserver cert file
+# @param arguments
+# @param ca_cert path to the ca cert
+# @param cert_path path to cert files
+# @param discover_etcd_servers enable puppetdb resource searching
+# @param ensure set ensure for installation or deinstallation
+# @param etcd_ca path to the etcd ca cert file
+# @param etcd_cert path to the etcd cert file
+# @param etcd_key path to the etcd key file
+# @param etcd_servers list etcd servers if no puppetdb is used
+# @param firewall_type define the type of firewall to use
+# @param front_proxy_cert
+# @param front_proxy_key
+# @param manage_firewall whether to manage firewall or not
+# @param puppetdb_discovery_tag enable puppetdb resource searching
+# @param service_cluster_cidr
+# @param serviceaccount_private
+# @param serviceaccount_public
+#
 class k8s::server::apiserver (
   K8s::Ensure $ensure = $k8s::server::ensure,
 
@@ -26,7 +51,7 @@ class k8s::server::apiserver (
   Stdlib::Unixpath $etcd_key               = "${cert_path}/etcd.key",
 
   Stdlib::IP::Address::Nosubnet $advertise_address = fact('networking.ip'),
-  K8s::Firewall $firewall_type = $k8s::server::firewall_type
+  K8s::Firewall $firewall_type                     = $k8s::server::firewall_type
 ) {
   assert_private()
 

--- a/manifests/server/apiserver.pp
+++ b/manifests/server/apiserver.pp
@@ -10,7 +10,6 @@ class k8s::server::apiserver (
   Boolean $discover_etcd_servers                 = $k8s::puppetdb_discovery,
   Boolean $manage_firewall                       = $k8s::server::manage_firewall,
   String $puppetdb_discovery_tag                 = $k8s::server::puppetdb_discovery_tag,
-
   Stdlib::Unixpath $cert_path              = $k8s::server::tls::cert_path,
   Stdlib::Unixpath $ca_cert                = $k8s::server::tls::ca_cert,
   Stdlib::Unixpath $aggregator_ca_cert     = $k8s::server::tls::aggregator_ca_cert,
@@ -25,6 +24,8 @@ class k8s::server::apiserver (
   Stdlib::Unixpath $etcd_ca                = "${cert_path}/etcd-ca.pem",
   Stdlib::Unixpath $etcd_cert              = "${cert_path}/etcd.pem",
   Stdlib::Unixpath $etcd_key               = "${cert_path}/etcd.key",
+
+  Stdlib::IP::Address::Nosubnet $advertise_address = fact('networking.ip'),
 ) {
   assert_private()
 
@@ -93,7 +94,7 @@ class k8s::server::apiserver (
         'Priority',
         'NodeRestriction',
       ],
-      advertise_address                  => fact('networking.ip'),
+      advertise_address                  => $advertise_address,
       allow_privileged                   => true,
       anonymous_auth                     => true,
       authorization_mode                 => ['Node', 'RBAC'],

--- a/manifests/server/apiserver.pp
+++ b/manifests/server/apiserver.pp
@@ -270,6 +270,8 @@ class k8s::server::apiserver (
   if $manage_firewall {
     case fact('os.family') {
       'Debian': {
+        include firewall
+
         firewall { '100 allow k8s apiserver access':
           dport  => 6443,
           proto  => 'tcp',

--- a/manifests/server/etcd.pp
+++ b/manifests/server/etcd.pp
@@ -141,6 +141,8 @@ class k8s::server::etcd (
   if $manage_firewall {
     case fact('os.family') {
       'Debian': {
+        include firewall
+
         firewall { '100 allow etcd server access':
           dport  => 2379,
           proto  => 'tcp',

--- a/manifests/server/etcd.pp
+++ b/manifests/server/etcd.pp
@@ -139,16 +139,33 @@ class k8s::server::etcd (
   }
 
   if $manage_firewall {
-    firewalld_service {
-      default:
-        ensure => $ensure,
-        zone   => 'public';
+    case fact('os.family') {
+      'Debian': {
+        firewall { '100 allow etcd server access':
+          dport  => 2379,
+          proto  => 'tcp',
+          action => 'accept',
+        }
+        firewall { '100 allow etcd client access':
+          dport  => 2380,
+          proto  => 'tcp',
+          action => 'accept',
+        }
+      }
+      'RedHat': {
+        firewalld_service {
+          default:
+            ensure => $ensure,
+            zone   => 'public';
 
-      'Allow etcd server access':
-        service => 'etcd-server';
+          'Allow etcd server access':
+            service => 'etcd-server';
 
-      'Allow etcd client access':
-        service => 'etcd-client';
+          'Allow etcd client access':
+            service => 'etcd-client';
+        }
+      }
+      default: {}
     }
   }
 }

--- a/manifests/server/kubeadm.pp
+++ b/manifests/server/kubeadm.pp
@@ -1,0 +1,11 @@
+# @summary Installs the kubeadm binary
+#
+# @param ensure
+#
+class k8s::server::kubeadm (
+  K8s::Ensure $ensure = $k8s::ensure,
+) {
+  k8s::binary { 'kubeadm':
+    ensure => $ensure,
+  }
+}

--- a/manifests/server/tls/k8s_sign.pp
+++ b/manifests/server/tls/k8s_sign.pp
@@ -13,8 +13,9 @@ define k8s::server::tls::k8s_sign (
   ].join(' | ')
 
   exec { "Sign ${name} cert":
-    path    => ['/usr/local/bin','/usr/bin','/bin'],
+    path    => $facts['path'],
     command => $exec_command,
     onlyif  => "kubectl --kubeconfig='${kubeconfig}' get csr | grep 'system:node:${name}' | grep Pending",
+    require => 'File[/usr/bin/kubectl]',
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -31,6 +31,14 @@
     {
       "name": "puppet-systemd",
       "version_requirement": ">= 2.0.0 < 4.0.0"
+    },
+    {
+      "name": "puppetlabs-firewall",
+      "version_requirement": ">= 4.0.0 < 6.0.0"
+    },
+    {
+      "name": "puppet-firewalld",
+      "version_requirement": ">= 4.5.0 < 6.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -52,7 +60,8 @@
       "operatingsystemrelease": [
         "18.04",
         "20.04",
-        "20.10"
+        "20.10",
+        "22.04"
       ]
     }
   ],

--- a/metadata.json
+++ b/metadata.json
@@ -21,6 +21,10 @@
       "version_requirement": ">= 3.2.0 < 4.0.0"
     },
     {
+      "name": "puppet-augeasproviders_core",
+      "version_requirement": ">= 2.4.0 < 4.0.0"
+    },
+    {
       "name": "herculesteam-augeasproviders_sysctl",
       "version_requirement": ">= 2.6.2 < 3.0.0"
     },

--- a/spec/classes/install/kubeadm_spec.rb
+++ b/spec/classes/install/kubeadm_spec.rb
@@ -2,16 +2,10 @@
 
 require 'spec_helper'
 
-describe 'k8s::node::kubectl' do
+describe 'k8s::install::kubeadm' do
   let(:pre_condition) do
     <<~PUPPET
-      function assert_private() {}
-
-      include ::k8s
-      class { '::k8s::node':
-        manage_kubelet => false,
-        manage_proxy => false,
-      }
+      include k8s
     PUPPET
   end
 

--- a/spec/classes/install/kubectl_spec.rb
+++ b/spec/classes/install/kubectl_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'k8s::install::kubectl' do
+  let(:pre_condition) do
+    <<~PUPPET
+      include k8s
+    PUPPET
+  end
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end

--- a/spec/type_aliases/firewall.rb
+++ b/spec/type_aliases/firewall.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'K8s::Firewall' do
+  describe 'valid firewall' do
+    %w[
+      iptables
+      firewalld
+    ].each do |value|
+      describe value.inspect do
+        it { is_expected.to allow_value(value) }
+      end
+    end
+  end
+
+  describe 'invalid firewall' do
+    [
+      nil,
+      [nil],
+      [nil, nil],
+      { 'foo' => 'bar' },
+      {},
+      '',
+      's',
+      'mailto:',
+      'blah',
+      '199',
+      600,
+      1_000,
+    ].each do |value|
+      describe value.inspect do
+        it { is_expected.not_to allow_value(value) }
+      end
+    end
+  end
+end

--- a/types/firewall.pp
+++ b/types/firewall.pp
@@ -1,0 +1,5 @@
+# @summary a type to describe the type of the firewall to use
+type K8s::Firewall = Enum[
+  'iptables',
+  'firewalld',
+]


### PR DESCRIPTION
- include firewall class for dependency packages
- add ubuntu 22.04 and module dependencies to metadata
- move kubectl and kubeadm to generic install classes
- add firewall also for non firewalld systems
- add kubeadm tool to controller
- update class documentation
- add module dependency for augeasproviders_core
- add dependencies between sysctl and kmod
- require file kubectl before using it
- allow to set advertise_address
