### PR TITLE
Use cascade=orphan for kubectl_apply resources when told to recreate

### DIFF
--- a/lib/puppet/provider/kubectl_apply/kubectl.rb
+++ b/lib/puppet/provider/kubectl_apply/kubectl.rb
@@ -25,7 +25,7 @@ Puppet::Type.type(:kubectl_apply).provide(:kubectl) do
     tempfile.write resource_hash.to_json
     tempfile.flush
     if resource[:recreate] && resource_diff && exists_in_cluster
-      kubectl_cmd 'delete', '-f', tempfile.path, '--cascade=false', '--wait=false'
+      kubectl_cmd 'delete', '-f', tempfile.path, '--cascade=orphan', '--wait=false'
       kubectl_cmd 'create', '-f', tempfile.path
     elsif resource_diff && exists_in_cluster
       kubectl_cmd 'patch', '-f', tempfile.path, '-p', resource_diff.to_json, '--type', 'merge'

--- a/spec/unit/puppet/provider/kubectl_apply_resource/kubectl_spec.rb
+++ b/spec/unit/puppet/provider/kubectl_apply_resource/kubectl_spec.rb
@@ -313,7 +313,7 @@ RSpec.describe kubectl_provider do
           expect(provider).to receive(:kubectl).with(
             '--namespace', 'kube-system',
             'delete', '-f', '/tmp/kubectl_apply',
-            '--cascade=false', '--wait=false'
+            '--cascade=orphan', '--wait=false'
           )
           expect(provider).to receive(:kubectl).with(
             '--namespace', 'kube-system',


### PR DESCRIPTION
The old `cascade=false` option is being fully removed from Kubernetes, and is in fact now deprecated on all supported versions. And even the most recent EoL versions understand `cascade=orphan`.

The recreate option might not be the most optimal design at the moment, but it should at least not error out if actually used.