### PR TITLE
Fix generated kube-proxy configmap

### DIFF
--- a/manifests/server/resources/kube_proxy.pp
+++ b/manifests/server/resources/kube_proxy.pp
@@ -128,7 +128,7 @@ class k8s::server::resources::kube_proxy (
           'kube-proxy.conf' => to_yaml({
               apiVersion  => 'kubeproxy.config.k8s.io/v1alpha1',
               kind        => 'KubeProxyConfiguration',
-              clusterCIDR => $cluster_cidr,
+              clusterCIDR => flatten($cluster_cidr).join(','),
           } + $extra_config),
         },
       };

--- a/manifests/server/resources/kube_proxy.pp
+++ b/manifests/server/resources/kube_proxy.pp
@@ -126,9 +126,12 @@ class k8s::server::resources::kube_proxy (
         },
         data     => {
           'kube-proxy.conf' => to_yaml({
-              apiVersion  => 'kubeproxy.config.k8s.io/v1alpha1',
-              kind        => 'KubeProxyConfiguration',
-              clusterCIDR => flatten($cluster_cidr).join(','),
+              apiVersion       => 'kubeproxy.config.k8s.io/v1alpha1',
+              kind             => 'KubeProxyConfiguration',
+              clusterCIDR      => flatten($cluster_cidr).join(','),
+              clientConnection => {
+                kubeconfig => '/var/lib/kube-proxy/kubeconfig',
+              },
           } + $extra_config),
         },
       };
@@ -174,7 +177,6 @@ class k8s::server::resources::kube_proxy (
                     k8s::format_arguments(
                       {
                         hostname_override => '$(NODE_NAME)',
-                        kubeconfig        => '/var/lib/kube-proxy/kubeconfig',
                         config            => '/var/lib/kube-proxy/kube-proxy.conf',
                       } + $extra_args
                     )

--- a/spec/fixtures/files/resources/kube-proxy-older.yaml
+++ b/spec/fixtures/files/resources/kube-proxy-older.yaml
@@ -27,7 +27,6 @@ spec:
         - "--alsologtostderr=true"
         - "--log-file=/var/log/kube-proxy.log"
         - "--hostname-override=$(NODE_NAME)"
-        - "--kubeconfig=/var/lib/kube-proxy/kubeconfig"
         - "--config=/var/lib/kube-proxy/kube-proxy.conf"
         env:
         - name: NODE_NAME

--- a/spec/fixtures/files/resources/kube-proxy.yaml
+++ b/spec/fixtures/files/resources/kube-proxy.yaml
@@ -29,7 +29,6 @@ spec:
         - "--"
         - "/usr/local/bin/kube-proxy"
         - "--hostname-override=$(NODE_NAME)"
-        - "--kubeconfig=/var/lib/kube-proxy/kubeconfig"
         - "--config=/var/lib/kube-proxy/kube-proxy.conf"
         env:
         - name: NODE_NAME


### PR DESCRIPTION
With dual-stack cluster CIDR this will generate a broken clusterCIDR parameter, as kube-proxy expects a comma-separated string.  
Additionally, when using the config file, any kubeconfig parameters specified in the launch options may be silently ignored.