### PR TITLE
Improve the kube-proxy management flag

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -66,6 +66,7 @@ Uses the cni-plugins bridge binary to create a bridge interface to connect the c
 * [`K8s::Node_auth`](#K8s--Node_auth): a type to describe node/kubelet authentication methods
 * [`K8s::PortRange`](#K8s--PortRange): This regexp matches port range values
 * [`K8s::Proxy_auth`](#K8s--Proxy_auth): a type to describe kube-proxy authentication methods
+* [`K8s::Proxy_method`](#K8s--Proxy_method): a type to describe how kube-proxy should be deployed
 * [`K8s::Quantity`](#K8s--Quantity): This regexp matches quantities, like those for resource requests/limits
 * [`K8s::TLS_altnames`](#K8s--TLS_altnames): a type to describe TLS alternative names in certificates
 * [`K8s::Timestamp`](#K8s--Timestamp): This regexp matches RFC3339 timestamps, the same as what Kubernetes expects to find
@@ -84,6 +85,7 @@ The following parameters are available in the `k8s` class:
 
 * [`manage_kernel_modules`](#-k8s--manage_kernel_modules)
 * [`manage_sysctl_settings`](#-k8s--manage_sysctl_settings)
+* [`manage_kube_proxy`](#-k8s--manage_kube_proxy)
 * [`ensure`](#-k8s--ensure)
 * [`packaging`](#-k8s--packaging)
 * [`native_packaging`](#-k8s--native_packaging)
@@ -104,7 +106,6 @@ The following parameters are available in the `k8s` class:
 * [`manage_repo`](#-k8s--manage_repo)
 * [`manage_packages`](#-k8s--manage_packages)
 * [`manage_container_manager`](#-k8s--manage_container_manager)
-* [`manage_kube_proxy`](#-k8s--manage_kube_proxy)
 * [`puppetdb_discovery`](#-k8s--puppetdb_discovery)
 * [`puppetdb_discovery_tag`](#-k8s--puppetdb_discovery_tag)
 * [`purge_manifests`](#-k8s--purge_manifests)
@@ -137,6 +138,15 @@ Default value: `true`
 Data type: `Boolean`
 
 A flag to manage required sysctl settings.
+
+Default value: `true`
+
+##### <a name="-k8s--manage_kube_proxy"></a>`manage_kube_proxy`
+
+Data type: `K8s::Proxy_method`
+
+How/if the kube-proxy component should be managed, either as an in-cluster
+component (default), or as an on-node component for advanced use-cases.
 
 Default value: `true`
 
@@ -293,14 +303,6 @@ Data type: `Boolean`
 Default value: `true`
 
 ##### <a name="-k8s--manage_container_manager"></a>`manage_container_manager`
-
-Data type: `Boolean`
-
-
-
-Default value: `true`
-
-##### <a name="-k8s--manage_kube_proxy"></a>`manage_kube_proxy`
 
 Data type: `Boolean`
 
@@ -754,7 +756,7 @@ Data type: `Boolean`
 
 whether to manage kube-proxy or not
 
-Default value: `false`
+Default value: `$k8s::manage_kube_proxy == 'on-node'`
 
 ##### <a name="-k8s--node--manage_sysctl_settings"></a>`manage_sysctl_settings`
 
@@ -3781,6 +3783,19 @@ Alias of `Pattern[/^[0-9]+(-[0-9]+)?$/]`
 a type to describe kube-proxy authentication methods
 
 Alias of `Enum['cert', 'token', 'incluster']`
+
+### <a name="K8s--Proxy_method"></a>`K8s::Proxy_method`
+
+a type to describe how kube-proxy should be deployed
+
+Alias of
+
+```puppet
+Variant[Enum[
+    'on-node',
+    'in-cluster',
+  ], Boolean]
+```
 
 ### <a name="K8s--Quantity"></a>`K8s::Quantity`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2191,9 +2191,9 @@ The following parameters are available in the `k8s::server::resources` class:
 * [`cluster_domain`](#-k8s--server--resources--cluster_domain)
 * [`master`](#-k8s--server--resources--master)
 * [`manage_bootstrap`](#-k8s--server--resources--manage_bootstrap)
-* [`manage_kube_proxy`](#-k8s--server--resources--manage_kube_proxy)
 * [`manage_coredns`](#-k8s--server--resources--manage_coredns)
 * [`manage_flannel`](#-k8s--server--resources--manage_flannel)
+* [`manage_kube_proxy`](#-k8s--server--resources--manage_kube_proxy)
 * [`kube_proxy_image`](#-k8s--server--resources--kube_proxy_image)
 * [`kube_proxy_tag`](#-k8s--server--resources--kube_proxy_tag)
 * [`kube_proxy_daemonset_config`](#-k8s--server--resources--kube_proxy_daemonset_config)
@@ -2263,14 +2263,6 @@ Data type: `Boolean`
 
 Default value: `true`
 
-##### <a name="-k8s--server--resources--manage_kube_proxy"></a>`manage_kube_proxy`
-
-Data type: `Boolean`
-
-
-
-Default value: `$k8s::manage_kube_proxy`
-
 ##### <a name="-k8s--server--resources--manage_coredns"></a>`manage_coredns`
 
 Data type: `Boolean`
@@ -2286,6 +2278,14 @@ Data type: `Boolean`
 
 
 Default value: `true`
+
+##### <a name="-k8s--server--resources--manage_kube_proxy"></a>`manage_kube_proxy`
+
+Data type: `K8s::Proxy_method`
+
+
+
+Default value: `$k8s::manage_kube_proxy`
 
 ##### <a name="-k8s--server--resources--kube_proxy_image"></a>`kube_proxy_image`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,6 +5,10 @@
 #
 # @param manage_sysctl_settings
 #   A flag to manage required sysctl settings.
+#
+# @param manage_kube_proxy
+#   How/if the kube-proxy component should be managed, either as an in-cluster
+#   component (default), or as an on-node component for advanced use-cases.
 # @param ensure
 # @param packaging
 class k8s (
@@ -25,15 +29,16 @@ class k8s (
   Optional[String[1]] $crictl_package        = undef,
   String[1] $runc_version                    = 'installed',
 
-  Boolean $manage_etcd              = true,
-  Boolean $manage_firewall          = false,
-  Boolean $manage_kernel_modules    = true,
-  Boolean $manage_sysctl_settings   = true,
-  Boolean $manage_image             = false,
-  Boolean $manage_repo              = true,
-  Boolean $manage_packages          = true,
-  Boolean $manage_container_manager = true,
-  Boolean $manage_kube_proxy        = true,
+  Boolean $manage_etcd                 = true,
+  Boolean $manage_firewall             = false,
+  Boolean $manage_kernel_modules       = true,
+  Boolean $manage_sysctl_settings      = true,
+  Boolean $manage_image                = false,
+  Boolean $manage_repo                 = true,
+  Boolean $manage_packages             = true,
+  Boolean $manage_container_manager    = true,
+  K8s::Proxy_method $manage_kube_proxy = true,
+
   Boolean $puppetdb_discovery       = false,
   String[1] $puppetdb_discovery_tag = 'default',
 

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -29,7 +29,7 @@ class k8s::node (
   K8s::Proxy_auth $proxy_auth = 'incluster',
 
   Boolean $manage_kubelet           = true,
-  Boolean $manage_proxy             = false,
+  Boolean $manage_proxy             = $k8s::manage_kube_proxy == 'on-node',
   Boolean $manage_crictl            = false,
   Boolean $manage_firewall          = $k8s::manage_firewall,
   Boolean $manage_kernel_modules    = $k8s::manage_kernel_modules,

--- a/manifests/server/resources.pp
+++ b/manifests/server/resources.pp
@@ -8,10 +8,10 @@ class k8s::server::resources (
   String[1] $cluster_domain              = $k8s::server::cluster_domain,
   String[1] $master                      = $k8s::server::master,
 
-  Boolean $manage_bootstrap  = true,
-  Boolean $manage_kube_proxy = $k8s::manage_kube_proxy,
-  Boolean $manage_coredns    = true,
-  Boolean $manage_flannel    = true,
+  Boolean $manage_bootstrap            = true,
+  Boolean $manage_coredns              = true,
+  Boolean $manage_flannel              = true,
+  K8s::Proxy_method $manage_kube_proxy = $k8s::manage_kube_proxy,
 
   String[1] $kube_proxy_image                    = 'k8s.gcr.io/kube-proxy',
   String[1] $kube_proxy_tag                      = "v${k8s::version}",
@@ -32,7 +32,7 @@ class k8s::server::resources (
     include k8s::server::resources::bootstrap
   }
 
-  if $manage_kube_proxy {
+  if $manage_kube_proxy and $manage_kube_proxy != 'on-node' {
     include k8s::server::resources::kube_proxy
   }
 

--- a/spec/type_aliases/proxy_method_spec.rb
+++ b/spec/type_aliases/proxy_method_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'K8s::Proxy_method' do
+  describe 'valid proxy_method' do
+    [
+      true,
+      false,
+      'on-node',
+      'in-cluster'
+    ].each do |value|
+      describe value.inspect do
+        it { is_expected.to allow_value(value) }
+      end
+    end
+  end
+
+  describe 'invalid proxy_auth' do
+    [
+      nil,
+      [nil],
+      [nil, nil],
+      { 'foo' => 'bar' },
+      {},
+      '',
+      's',
+      'mailto:',
+      'blah',
+      '199',
+      600,
+      1_000,
+    ].each do |value|
+      describe value.inspect do
+        it { is_expected.not_to allow_value(value) }
+      end
+    end
+  end
+end

--- a/types/proxy_method.pp
+++ b/types/proxy_method.pp
@@ -1,0 +1,8 @@
+# @summary a type to describe how kube-proxy should be deployed
+type K8s::Proxy_method = Variant[
+  Enum[
+    'on-node',
+    'in-cluster',
+  ],
+  Boolean
+]


### PR DESCRIPTION
Since this seems like it could be quite the footgun, it's probably best to use a type that makes it harder to deploy a broken cluster.  
It probably won't stop anyone determined enough, but it should at least make it easier to know what's going to happen based on the value assigned.

Fixes #28 