### PR TITLE
Include every IP address into a cert's SAN field

### DIFF
--- a/manifests/server/etcd.pp
+++ b/manifests/server/etcd.pp
@@ -36,12 +36,11 @@ class k8s::server::etcd (
     $addn_names = [
       fact('networking.hostname'),
       fact('networking.fqdn'),
-      fact('networking.ip'),
-      fact('networking.ip6'),
       'localhost',
-      '127.0.0.1',
-      '::1',
-    ]
+      $facts.get('networking.interfaces', {}).map |$_,$v| {
+        ($v.get('bindings', []) + $v.get('bindings6', [])).map |$x| { $x.get('address') }
+      }.filter |$x| { !empty($x) },
+    ].flatten.sort.unique
 
     k8s::server::tls::ca {
       default:

--- a/manifests/server/tls.pp
+++ b/manifests/server/tls.pp
@@ -94,23 +94,21 @@ class k8s::server::tls (
         extended_key_usage => ['serverAuth'],
         # prevent undef value if ipv6 is turned off
         addn_names         => delete_undef_values(
-          (
-            [
-              'kubernetes',
-              'kubernetes.default',
-              'kubernetes.default.svc',
-              "kubernetes.default.svc.${cluster_domain}",
-              'kubernetes.service.discover',
-              'localhost',
-              fact('networking.hostname'),
-              fact('networking.fqdn'),
-              $api_service_address,
-              '127.0.0.1',
-              '::1',
-              fact('networking.ip'),
-              fact('networking.ip6'),
-            ] + $api_addn_names
-          ).unique()
+          [
+            'kubernetes',
+            'kubernetes.default',
+            'kubernetes.default.svc',
+            "kubernetes.default.svc.${cluster_domain}",
+            'kubernetes.service.discover',
+            'localhost',
+            fact('networking.hostname'),
+            fact('networking.fqdn'),
+            $api_service_address,
+            $api_addn_names,
+            $facts.get('networking.interfaces', {}).map |$_,$v| {
+              ($v.get('bindings', []) + $v.get('bindings6', [])).map |$x| { $x.get('address') }
+            }.filter |$x| { !empty($x) },
+          ].flatten.sort.unique
         ),
         distinguished_name => {
           commonName => 'kube-apiserver',


### PR DESCRIPTION
Just localhost and default routed IPs were added to a SAN before. That causes a problem on a server with multiple NICs when etcd or kube-apiserver should be accessed via non-default route.
