### PR TITLE
Revert "Include every IP address into a cert's SAN field"

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1789,6 +1789,7 @@ The following parameters are available in the `k8s::server::etcd` class:
 * [`self_signed_tls`](#-k8s--server--etcd--self_signed_tls)
 * [`manage_certs`](#-k8s--server--etcd--manage_certs)
 * [`generate_ca`](#-k8s--server--etcd--generate_ca)
+* [`addn_names`](#-k8s--server--etcd--addn_names)
 * [`cert_path`](#-k8s--server--etcd--cert_path)
 * [`peer_ca_key`](#-k8s--server--etcd--peer_ca_key)
 * [`peer_ca_cert`](#-k8s--server--etcd--peer_ca_cert)
@@ -1875,6 +1876,14 @@ Data type: `Boolean`
 
 
 Default value: `false`
+
+##### <a name="-k8s--server--etcd--addn_names"></a>`addn_names`
+
+Data type: `K8s::TLS_altnames`
+
+
+
+Default value: `[]`
 
 ##### <a name="-k8s--server--etcd--cert_path"></a>`cert_path`
 

--- a/manifests/server/etcd.pp
+++ b/manifests/server/etcd.pp
@@ -33,11 +33,12 @@ class k8s::server::etcd (
     $addn_names = [
       fact('networking.hostname'),
       fact('networking.fqdn'),
+      fact('networking.ip'),
+      fact('networking.ip6'),
       'localhost',
-      $facts.get('networking.interfaces', {}).map |$_,$v| {
-        ($v.get('bindings', []) + $v.get('bindings6', [])).map |$x| { $x.get('address') }
-      }.filter |$x| { !empty($x) },
-    ].flatten.sort.unique
+      '127.0.0.1',
+      '::1',
+    ]
 
     k8s::server::tls::ca {
       default:

--- a/manifests/server/tls.pp
+++ b/manifests/server/tls.pp
@@ -84,21 +84,23 @@ class k8s::server::tls (
         extended_key_usage => ['serverAuth'],
         # prevent undef value if ipv6 is turned off
         addn_names         => delete_undef_values(
-          [
-            'kubernetes',
-            'kubernetes.default',
-            'kubernetes.default.svc',
-            "kubernetes.default.svc.${cluster_domain}",
-            'kubernetes.service.discover',
-            'localhost',
-            fact('networking.hostname'),
-            fact('networking.fqdn'),
-            $api_service_address,
-            $api_addn_names,
-            $facts.get('networking.interfaces', {}).map |$_,$v| {
-              ($v.get('bindings', []) + $v.get('bindings6', [])).map |$x| { $x.get('address') }
-            }.filter |$x| { !empty($x) },
-          ].flatten.sort.unique
+          (
+            [
+              'kubernetes',
+              'kubernetes.default',
+              'kubernetes.default.svc',
+              "kubernetes.default.svc.${cluster_domain}",
+              'kubernetes.service.discover',
+              'localhost',
+              fact('networking.hostname'),
+              fact('networking.fqdn'),
+              $api_service_address,
+              '127.0.0.1',
+              '::1',
+              fact('networking.ip'),
+              fact('networking.ip6'),
+            ] + $api_addn_names
+          ).unique()
         ),
         distinguished_name => {
           commonName => 'kube-apiserver',


### PR DESCRIPTION
Reverts voxpupuli/puppet-k8s#32

To copy [what I said there](https://github.com/voxpupuli/puppet-k8s/pull/32#issuecomment-1506824282);
It's causing issues as it's changing the SAN list - and therefore also triggering a recreation of the serving certs - every time a container starts or stops on the Kubernetes master nodes.

Additionally, it's also including link-local bindings as well as IPVS entries from kube-proxy into the certificates, which causes the SAN list to grow in size far too quickly. A simple test cluster with no active load is already up to 50 SANs, while our production cluster would have SAN lists with almost a thousand entries for each master.