### PR TITLE
Fix unintentional CA recreation if missing serial

### DIFF
--- a/manifests/server/tls/ca.pp
+++ b/manifests/server/tls/ca.pp
@@ -28,7 +28,7 @@ define k8s::server::tls::ca (
     -> exec { "Create ${title} CA cert":
       command   => "openssl req -x509 -new -nodes -key '${key}' \
         -days '${valid_days}' -out '${cert}' -subj '${subject}'",
-      unless    => "openssl x509 -CA '${cert}' -CAkey '${key}' -in '${cert}' -noout",
+      unless    => "openssl x509 -CA '${cert}' -CAkey '${key}' -in '${cert}' -noout -set_serial 00",
       path      => $facts['path'],
       subscribe => File[$key],
       before    => File[$cert],

--- a/spec/defines/server/tls/ca_spec.rb
+++ b/spec/defines/server/tls/ca_spec.rb
@@ -27,7 +27,7 @@ describe 'k8s::server::tls::ca' do
       it do
         is_expected.to contain_exec('Create namevar CA cert').with(
           command: %r{openssl req -x509 -new -nodes -key '/tmp/ca.key'\s+-days '10000' -out '/tmp/ca.pem' -subj '/CN=namevar'},
-          unless: "openssl x509 -CA '/tmp/ca.pem' -CAkey '/tmp/ca.key' -in '/tmp/ca.pem' -noout"
+          unless: "openssl x509 -CA '/tmp/ca.pem' -CAkey '/tmp/ca.key' -in '/tmp/ca.pem' -noout -set_serial 00"
         ).that_subscribes_to('File[/tmp/ca.key]')
       end
 


### PR DESCRIPTION
If there's no serial file on disk (no certificate has been signed by the CA), then openssl runs into issues trying to validate the CA against itself, which causes it to regenerate the CA even though it's still valid.

Fixes #37