### PR TITLE
Handle file mode for kubeconfig files

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -3412,6 +3412,7 @@ The following parameters are available in the `kubeconfig` type.
 * [`current_context`](#-kubeconfig--current_context)
 * [`embed_certs`](#-kubeconfig--embed_certs)
 * [`group`](#-kubeconfig--group)
+* [`mode`](#-kubeconfig--mode)
 * [`namespace`](#-kubeconfig--namespace)
 * [`owner`](#-kubeconfig--owner)
 * [`password`](#-kubeconfig--password)
@@ -3464,6 +3465,12 @@ Default value: `true`
 ##### <a name="-kubeconfig--group"></a>`group`
 
 The owner of the kubeconfig file
+
+##### <a name="-kubeconfig--mode"></a>`mode`
+
+The access mode of the kubeconfig file
+
+Default value: `0600`
 
 ##### <a name="-kubeconfig--namespace"></a>`namespace`
 

--- a/lib/puppet/provider/kubeconfig/ruby.rb
+++ b/lib/puppet/provider/kubeconfig/ruby.rb
@@ -44,9 +44,9 @@ Puppet::Type.type(:kubeconfig).provide(:ruby) do
 
   def chmod
     mode = resource[:mode]
-    mode = mode.to_i(8) if mode.is_a?(String) && mode =~ %r{^[0-7]+$}
+    raise Puppet::Error, "File mode is invalid" unless mode.is_a?(String) && mode =~ %r{^0[0-7]{3}$}
 
-    FileUtils.chmod(mode, resource[:path])
+    FileUtils.chmod(mode.to_i(8), resource[:path])
   end
 
   def find_cluster

--- a/lib/puppet/provider/kubeconfig/ruby.rb
+++ b/lib/puppet/provider/kubeconfig/ruby.rb
@@ -23,7 +23,9 @@ Puppet::Type.type(:kubeconfig).provide(:ruby) do
     update_current_context if resource[:current_context]
 
     save if changed?
+
     chown
+    chmod
   end
 
   def destroy
@@ -38,6 +40,13 @@ Puppet::Type.type(:kubeconfig).provide(:ruby) do
 
   def chown
     FileUtils.chown(resource[:owner], resource[:group], resource[:path])
+  end
+
+  def chmod
+    mode = resource[:mode]
+    mode = mode.to_i(8) if mode.is_a?(String) && mode =~ %r{^[0-7]+$}
+
+    FileUtils.chmod(mode, resource[:path])
   end
 
   def find_cluster

--- a/lib/puppet/type/kubeconfig.rb
+++ b/lib/puppet/type/kubeconfig.rb
@@ -60,8 +60,27 @@ Puppet::Type.newtype(:kubeconfig) do
     desc 'The owner of the kubeconfig file'
   end
   newparam(:mode) do
+    require 'puppet/util/symbolic_file_mode'
+    include Puppet::Util::SymbolicFileMode
+
     desc 'The access mode of the kubeconfig file'
     defaultto '0600'
+
+    validate do |value|
+      raise Puppet::Error, "The file mode specification must be a string, not '#{value.class.name}'" unless value.is_a? String
+      raise Puppet::Error, "The file mode specification is invalid: #{value.inspect}" unless value.nil? || valid_symbolic_mode?(value)
+    end
+
+    munge do |value|
+      return nil if value.nil?
+      raise Puppet::Error, "The file mode specification is invalid: #{value.inspect}" unless valid_symbolic_mode?(value)
+
+      "0#{symbolic_mode_to_int(normalize_symbolic_mode(value)).to_s(8)}"
+    end
+
+    unmunge do |value|
+      display_mode(value) if value
+    end
   end
 
   newparam(:cluster) do

--- a/lib/puppet/type/kubeconfig.rb
+++ b/lib/puppet/type/kubeconfig.rb
@@ -59,6 +59,10 @@ Puppet::Type.newtype(:kubeconfig) do
   newparam(:group) do
     desc 'The owner of the kubeconfig file'
   end
+  newparam(:mode) do
+    desc 'The access mode of the kubeconfig file'
+    defaultto '0600'
+  end
 
   newparam(:cluster) do
     desc 'The name of the cluster to manage in the kubeconfig file'

--- a/spec/unit/puppet/provider/kubeconfig/kubectl_spec.rb
+++ b/spec/unit/puppet/provider/kubeconfig/kubectl_spec.rb
@@ -111,6 +111,7 @@ RSpec.describe kubectl_provider do
           resource[:current_context]
         )
         expect(FileUtils).to receive(:chown).with(resource[:owner], resource[:group], resource[:path])
+        expect(FileUtils).to receive(:chmod).with(0o600, resource[:path])
 
         provider.create
       end

--- a/spec/unit/puppet/provider/kubeconfig/ruby_spec.rb
+++ b/spec/unit/puppet/provider/kubeconfig/ruby_spec.rb
@@ -64,6 +64,9 @@ RSpec.describe ruby_provider do
       it 'creates default config, updates components' do
         provider.create
 
+        stat = File.stat(tmpfile)
+        expect(stat.mode & 0o777).to eq 0o600
+
         expect(Psych.load(File.read(tmpfile))).to eq default_kubeconfig
       end
     end

--- a/spec/unit/puppet/type/kubeconfig_spec.rb
+++ b/spec/unit/puppet/type/kubeconfig_spec.rb
@@ -71,6 +71,20 @@ describe Puppet::Type.type(:kubeconfig) do
     end
   end
 
+  describe 'with complex symbolic mode' do
+    let(:resource) do
+      Puppet::Type.type(:kubeconfig).new(
+        path: '/tmp/kubeconfig',
+        server: 'https://kubernetes.home.lan:6443',
+        mode: 'u-x+rw,g-rwx,o-rwx'
+      )
+    end
+
+    it 'is munged to 0600' do
+      expect(resource[:mode]).to eq '0600'
+    end
+  end
+
   describe 'archive autorequire' do
     let(:file_resource) { Puppet::Type.type(:file).new(name: '/tmp') }
     let(:kubeconfig_resource) do

--- a/spec/unit/puppet/type/kubeconfig_spec.rb
+++ b/spec/unit/puppet/type/kubeconfig_spec.rb
@@ -20,6 +20,7 @@ describe Puppet::Type.type(:kubeconfig) do
     it { expect(resource[:namespace]).to eq 'default' }
     it { expect(resource[:skip_tls_verify]).not_to eq :true }
     it { expect(resource[:embed_certs]).to eq :true }
+    it { expect(resource[:mode]).to eq '0600' }
   end
 
   it 'verify resource[:path] is absolute filepath' do

--- a/spec/unit/puppet/type/kubeconfig_spec.rb
+++ b/spec/unit/puppet/type/kubeconfig_spec.rb
@@ -43,6 +43,34 @@ describe Puppet::Type.type(:kubeconfig) do
     expect { resource[:token_file] = 'relative/file' }.to raise_error(Puppet::Error, %r{File paths must be fully qualified, not 'relative/file'})
   end
 
+  describe 'with numeric mode' do
+    let(:resource) do
+      Puppet::Type.type(:kubeconfig).new(
+        path: '/tmp/kubeconfig',
+        server: 'https://kubernetes.home.lan:6443',
+        mode: '0640'
+      )
+    end
+
+    it 'is munged to 0640' do
+      expect(resource[:mode]).to eq '0640'
+    end
+  end
+
+  describe 'with symbolic mode' do
+    let(:resource) do
+      Puppet::Type.type(:kubeconfig).new(
+        path: '/tmp/kubeconfig',
+        server: 'https://kubernetes.home.lan:6443',
+        mode: 'u=rw,g=r'
+      )
+    end
+
+    it 'is munged to 0640' do
+      expect(resource[:mode]).to eq '0640'
+    end
+  end
+
   describe 'archive autorequire' do
     let(:file_resource) { Puppet::Type.type(:file).new(name: '/tmp') }
     let(:kubeconfig_resource) do


### PR DESCRIPTION
Probably not the most optimal implementation, though it's best to at least ensure it's 0600 by default.