### PR TITLE
remove duplicate CRB and move SA to kube-proxy class

### DIFF
--- a/manifests/server/resources.pp
+++ b/manifests/server/resources.pp
@@ -96,28 +96,6 @@ class k8s::server::resources (
           apiGroup => 'rbac.authorization.k8s.io',
         },
       };
-
-    'kube-proxy RoleBinding':
-      resource_name => 'kube-proxy',
-      content       => {
-        metadata => {
-          labels => {
-            'kubernetes.io/managed-by' => 'puppet',
-          },
-        },
-        subjects => [
-          {
-            kind      => 'ServiceAccount',
-            name      => 'kube-proxy',
-            namespace => 'kube-system',
-          },
-        ],
-        roleRef  => {
-          kind     => 'ClusterRole',
-          name     => 'system:node-proxier',
-          apiGroup => 'rbac.authorization.k8s.io',
-        },
-      };
   }
   # Service accounts
   kubectl_apply {
@@ -137,9 +115,6 @@ class k8s::server::resources (
 
     'kube-controller-manager SA':
       resource_name => 'kube-controller-manager';
-
-    'kube-proxy SA':
-      resource_name => 'kube-proxy';
   }
   # Config maps
   kubectl_apply {

--- a/manifests/server/resources/kube_proxy.pp
+++ b/manifests/server/resources/kube_proxy.pp
@@ -42,11 +42,21 @@ class k8s::server::resources::kube_proxy (
       resource_name => 'kube-proxy',
       namespace     => 'kube-system';
 
+    'kube-proxy ServiceAccount':
+      api_version => 'v1',
+      kind        => 'ServiceAccount',
+      content     => {
+        metadata => {
+          labels => {
+            'kubernetes.io/managed-by' => 'puppet',
+          },
+        },
+      };
+
     'kube-proxy ClusterRoleBinding':
-      api_version   => 'rbac.authorization.k8s.io/v1',
-      kind          => 'ClusterRoleBinding',
-      resource_name => 'kube-proxy',
-      content       => {
+      api_version => 'rbac.authorization.k8s.io/v1',
+      kind        => 'ClusterRoleBinding',
+      content     => {
         metadata => {
           labels => {
             'kubernetes.io/managed-by' => 'puppet',

--- a/spec/classes/server/resources/kube_proxy_spec.rb
+++ b/spec/classes/server/resources/kube_proxy_spec.rb
@@ -29,6 +29,7 @@ describe 'k8s::server::resources::kube_proxy' do
 
       it { is_expected.to compile }
 
+      it { is_expected.to contain_kubectl_apply('kube-proxy ServiceAccount') }
       it { is_expected.to contain_kubectl_apply('kube-proxy ClusterRoleBinding') }
       it { is_expected.to contain_kubectl_apply('kube-proxy ConfigMap') }
 


### PR DESCRIPTION
- remove duplicated clusterRoleBinding from k8s::server::resource class
- add ServiceAccount to k8s::server::resource::kube_proxy class
- remove ServiceAccount from k8s::server::resource
- remove default value from specific resource declaration