### PR TITLE
add possibillity to use imagePullSecrets

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2348,6 +2348,7 @@ Generates and deploys standard Kubernetes in-cluster services
 
 The following parameters are available in the `k8s::server::resources` class:
 
+* [`image_pull_secrets`](#-k8s--server--resources--image_pull_secrets)
 * [`kubeconfig`](#-k8s--server--resources--kubeconfig)
 * [`cluster_cidr`](#-k8s--server--resources--cluster_cidr)
 * [`dns_service_address`](#-k8s--server--resources--dns_service_address)
@@ -2370,6 +2371,14 @@ The following parameters are available in the `k8s::server::resources` class:
 * [`flannel_image`](#-k8s--server--resources--flannel_image)
 * [`flannel_tag`](#-k8s--server--resources--flannel_tag)
 * [`flannel_daemonset_config`](#-k8s--server--resources--flannel_daemonset_config)
+
+##### <a name="-k8s--server--resources--image_pull_secrets"></a>`image_pull_secrets`
+
+Data type: `Optional[Array]`
+
+the secrets to pull from private registries
+
+Default value: `undef`
 
 ##### <a name="-k8s--server--resources--kubeconfig"></a>`kubeconfig`
 
@@ -2606,6 +2615,7 @@ The following parameters are available in the `k8s::server::resources::coredns` 
 * [`image_tag`](#-k8s--server--resources--coredns--image_tag)
 * [`deployment_config`](#-k8s--server--resources--coredns--deployment_config)
 * [`hosts`](#-k8s--server--resources--coredns--hosts)
+* [`image_pull_secrets`](#-k8s--server--resources--coredns--image_pull_secrets)
 * [`ensure`](#-k8s--server--resources--coredns--ensure)
 * [`kubeconfig`](#-k8s--server--resources--coredns--kubeconfig)
 * [`cluster_domain`](#-k8s--server--resources--coredns--cluster_domain)
@@ -2650,6 +2660,14 @@ Additional host-style entries for the CoreDNS deployment to serve
 
 Default value: `[]`
 
+##### <a name="-k8s--server--resources--coredns--image_pull_secrets"></a>`image_pull_secrets`
+
+Data type: `Optional[Array]`
+
+the secrets to pull from private registries
+
+Default value: `$k8s::server::resources::image_pull_secrets`
+
 ##### <a name="-k8s--server--resources--coredns--ensure"></a>`ensure`
 
 Data type: `K8s::Ensure`
@@ -2689,6 +2707,7 @@ The following parameters are available in the `k8s::server::resources::flannel` 
 * [`image_tag`](#-k8s--server--resources--flannel--image_tag)
 * [`daemonset_config`](#-k8s--server--resources--flannel--daemonset_config)
 * [`net_config`](#-k8s--server--resources--flannel--net_config)
+* [`image_pull_secrets`](#-k8s--server--resources--flannel--image_pull_secrets)
 * [`ensure`](#-k8s--server--resources--flannel--ensure)
 * [`kubeconfig`](#-k8s--server--resources--flannel--kubeconfig)
 
@@ -2748,6 +2767,14 @@ Additional configuration to merge into net-conf.json for Flannel
 
 Default value: `{}`
 
+##### <a name="-k8s--server--resources--flannel--image_pull_secrets"></a>`image_pull_secrets`
+
+Data type: `Optional[Array]`
+
+the secrets to pull from private registries
+
+Default value: `$k8s::server::resources::image_pull_secrets`
+
 ##### <a name="-k8s--server--resources--flannel--ensure"></a>`ensure`
 
 Data type: `K8s::Ensure`
@@ -2778,6 +2805,7 @@ The following parameters are available in the `k8s::server::resources::kube_prox
 * [`daemonset_config`](#-k8s--server--resources--kube_proxy--daemonset_config)
 * [`extra_args`](#-k8s--server--resources--kube_proxy--extra_args)
 * [`extra_config`](#-k8s--server--resources--kube_proxy--extra_config)
+* [`image_pull_secrets`](#-k8s--server--resources--kube_proxy--image_pull_secrets)
 * [`ensure`](#-k8s--server--resources--kube_proxy--ensure)
 * [`kubeconfig`](#-k8s--server--resources--kube_proxy--kubeconfig)
 
@@ -2828,6 +2856,14 @@ Data type: `Hash[String,Data]`
 Additional configuration data to apply to the kube-proxy configuration file
 
 Default value: `{}`
+
+##### <a name="-k8s--server--resources--kube_proxy--image_pull_secrets"></a>`image_pull_secrets`
+
+Data type: `Optional[Array]`
+
+the secrets to pull from private registries
+
+Default value: `$k8s::server::resources::image_pull_secrets`
 
 ##### <a name="-k8s--server--resources--kube_proxy--ensure"></a>`ensure`
 

--- a/manifests/server/resources.pp
+++ b/manifests/server/resources.pp
@@ -1,4 +1,6 @@
 # @summary Generates and deploys standard Kubernetes in-cluster services
+# @param image_pull_secrets the secrets to pull from private registries
+#
 class k8s::server::resources (
   Stdlib::Unixpath $kubeconfig = '/root/.kube/config',
 
@@ -25,6 +27,7 @@ class k8s::server::resources (
   String[1] $flannel_image                       = 'rancher/mirrored-flannelcni-flannel',
   String[1] $flannel_tag                         = 'v0.16.1',
   Hash[String,Data] $flannel_daemonset_config    = {},
+  Optional[Array] $image_pull_secrets            = undef,
 ) {
   assert_private()
 

--- a/manifests/server/resources/coredns.pp
+++ b/manifests/server/resources/coredns.pp
@@ -5,6 +5,8 @@
 # @param image_tag The CoreDNS image tag to use
 # @param deployment_config Additional configuration to merge into the Kubernetes Deployment object
 # @param hosts Additional host-style entries for the CoreDNS deployment to serve
+# @param image_pull_secrets the secrets to pull from private registries
+#
 class k8s::server::resources::coredns (
   K8s::Ensure $ensure                    = $k8s::ensure,
   Stdlib::Unixpath $kubeconfig           = $k8s::server::resources::kubeconfig,
@@ -12,6 +14,7 @@ class k8s::server::resources::coredns (
   String[1] $cluster_domain              = $k8s::server::resources::cluster_domain,
   String[1] $image                       = $k8s::server::resources::coredns_image,
   String[1] $image_tag                   = $k8s::server::resources::coredns_tag,
+  Optional[Array] $image_pull_secrets    = $k8s::server::resources::image_pull_secrets,
   Hash[String,Data] $deployment_config   = $k8s::server::resources::coredns_deployment_config,
   Array[String[1]] $hosts                = [],
 ) {
@@ -274,6 +277,7 @@ class k8s::server::resources::coredns (
                   },
                 },
               ],
+              imagePullSecrets   => $image_pull_secrets,
               dnsPolicy          => 'Default',
               volumes            => [
                 {

--- a/manifests/server/resources/flannel.pp
+++ b/manifests/server/resources/flannel.pp
@@ -7,6 +7,8 @@
 # @param image_tag The Flannel image tag to use
 # @param daemonset_config Additional configuration to merge into the DaemonSet object
 # @param net_config Additional configuration to merge into net-conf.json for Flannel
+# @param image_pull_secrets the secrets to pull from private registries
+#
 class k8s::server::resources::flannel (
   K8s::Ensure $ensure                 = $k8s::ensure,
   Stdlib::Unixpath $kubeconfig        = $k8s::server::resources::kubeconfig,
@@ -16,6 +18,7 @@ class k8s::server::resources::flannel (
   String[1] $image                    = $k8s::server::resources::flannel_image,
   String[1] $image_tag                = $k8s::server::resources::flannel_tag,
   Hash[String,Data] $daemonset_config = $k8s::server::resources::flannel_daemonset_config,
+  Optional[Array] $image_pull_secrets = $k8s::server::resources::image_pull_secrets,
   Hash[String,Data] $net_config       = {},
 ) {
   assert_private()
@@ -243,6 +246,7 @@ class k8s::server::resources::flannel (
                   ],
                 },
               ],
+              imagePullSecrets   => $image_pull_secrets,
               initContainers     => [
                 {
                   name         => 'install-cni-plugin',

--- a/manifests/server/resources/kube_proxy.pp
+++ b/manifests/server/resources/kube_proxy.pp
@@ -6,12 +6,15 @@
 # @param daemonset_config Additional configuration to merge into the DaemonSet object
 # @param extra_args Additional arguments to specify to the kube-proxy application
 # @param extra_config Additional configuration data to apply to the kube-proxy configuration file
+# @param image_pull_secrets the secrets to pull from private registries
+#
 class k8s::server::resources::kube_proxy (
   K8s::Ensure $ensure                    = $k8s::ensure,
   Stdlib::Unixpath $kubeconfig           = $k8s::server::resources::kubeconfig,
   K8s::CIDR $cluster_cidr                = $k8s::server::resources::cluster_cidr,
   String[1] $image                       = $k8s::server::resources::kube_proxy_image,
   String[1] $image_tag                   = $k8s::server::resources::kube_proxy_tag,
+  Optional[Array] $image_pull_secrets    = $k8s::server::resources::image_pull_secrets,
   Hash[String,Data] $daemonset_config    = {},
   Hash[String,Data] $extra_args          = {},
   Hash[String,Data] $extra_config        = {},
@@ -239,6 +242,7 @@ class k8s::server::resources::kube_proxy (
                   ],
                 }
               ],
+              imagePullSecrets   => $image_pull_secrets,
               hostNetwork        => true,
               priorityClassName  => 'system-node-critical',
               serviceAccountName => 'kube-proxy',

--- a/spec/fixtures/files/resources/kube-proxy-older.yaml
+++ b/spec/fixtures/files/resources/kube-proxy-older.yaml
@@ -52,6 +52,7 @@ spec:
           readOnly: true
         - mountPath: "/run/xtables.lock"
           name: iptables-lock
+      imagePullSecrets: null
       hostNetwork: true
       priorityClassName: system-node-critical
       serviceAccountName: kube-proxy

--- a/spec/fixtures/files/resources/kube-proxy.yaml
+++ b/spec/fixtures/files/resources/kube-proxy.yaml
@@ -54,6 +54,7 @@ spec:
           readOnly: true
         - mountPath: "/run/xtables.lock"
           name: iptables-lock
+      imagePullSecrets: null
       hostNetwork: true
       priorityClassName: system-node-critical
       serviceAccountName: kube-proxy


### PR DESCRIPTION
Add imagePullSecrets to pull images from private registries. 
Does not manage the secret itself. only use existing secrets.

First setup control plane, maybe with errors because coredns/kube-proxy cannot be deployed. Then create the secret. Images should then be pulled automatically.

```yaml
---
k8s::server::resources::image_pull_secrets:
  - name: my-private-registry-secret
```