### PR TITLE
Preliminary SUSE support

### DIFF
--- a/manifests/install/container_runtime.pp
+++ b/manifests/install/container_runtime.pp
@@ -42,6 +42,13 @@ class k8s::install::container_runtime (
           target  => '/usr/sbin/runc',
           replace => false,
         }
+      } elsif fact('os.family') == 'Suse' {
+        file { '/etc/crio/crio.conf':
+          ensure => file,
+        }
+        file { '/usr/libexec/crio':
+          ensure => directory,
+        }
       } else {
         $pkg = pick($crio_package, 'cri-o')
       }

--- a/manifests/node/kubelet.pp
+++ b/manifests/node/kubelet.pp
@@ -262,6 +262,17 @@ class k8s::node::kubelet (
     enable => true,
   }
 
+  if fact('os.family') == 'Suse' {
+    # Remove pre-packaged kubeadmin-built kubelet configuration on SUSE
+    file {
+      default:
+        ensure  => absent;
+
+      '/usr/lib/systemd/system/kubelet.service':;
+      '/usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf':;
+    }
+  }
+
   Class['k8s::install::container_runtime'] -> Service['kubelet']
   Package <| title == 'containernetworking-plugins' |> -> Service['kubelet']
 


### PR DESCRIPTION
Adds preliminary support for SUSE (Tested locally with an openSUSE 15.5 install)

Not going to mark it as supported in the manifest yet though, going to want to run through a few more installs to make sure there's nothing else that could cause issues.

Both CRI-o and containerd are in the core repo though, so things in general seem to behave just fine.