### PR TITLE
Fix RedHat urls

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -54,8 +54,9 @@ class k8s::repo (
       }
     }
     'RedHat': {
-      $libcontainers_url = "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_${fact('os.release.major')}_Stream/"
-      $crio_url          = "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/${crio_version}/CentOS_${fact('os.release.major')}_Stream/"
+      $release_name = if fact('os.release.major') > 7 { "CentOS_${fact('os.release.major')}_Stream" } else { "CentOS_${fact('os.release.major')}" }
+      $libcontainers_url = "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/${release_name}/"
+      $crio_url          = "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/${crio_version}/${release_name}/"
 
       yumrepo { 'libcontainers:stable':
         descr    => 'Stable releases of libcontainers',

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -54,8 +54,8 @@ class k8s::repo (
       }
     }
     'RedHat': {
-      $libcontainers_url = "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_${fact('os.release.major')}/"
-      $crio_url          = "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/${crio_version}/CentOS_${fact('os.release.major')}/"
+      $libcontainers_url = "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_${fact('os.release.major')}_Stream/"
+      $crio_url          = "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/${crio_version}/CentOS_${fact('os.release.major')}_Stream/"
 
       yumrepo { 'libcontainers:stable':
         descr    => 'Stable releases of libcontainers',

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -54,7 +54,7 @@ class k8s::repo (
       }
     }
     'RedHat': {
-      $release_name = if fact('os.release.major') > 7 { "CentOS_${fact('os.release.major')}_Stream" } else { "CentOS_${fact('os.release.major')}" }
+      $release_name = if versioncmp(fact('os.release.major'), '7') == 1 { "CentOS_${fact('os.release.major')}_Stream" } else { "CentOS_${fact('os.release.major')}" }
       $libcontainers_url = "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/${release_name}/"
       $crio_url          = "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/${crio_version}/${release_name}/"
 

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -17,5 +17,17 @@ describe 'k8s::repo' do
 
       it { is_expected.to compile }
     end
+    context 'on RedHat/CentOS 7, 8 and 9' do
+      let(:facts) { os_facts }
+      if os['family'] == 'RedHat' and os['release']['major'] == '7'
+        it { is_expected.to contain_yumrepo('libcontainers:stable').with_baseurl => 'https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_7/'}
+      end
+      if os['family'] == 'RedHat' and os['release']['major'] == '8'
+        it { is_expected.to contain_yumrepo('libcontainers:stable').with_baseurl => 'https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_8_Stream/'}
+      end
+      if os['family'] == 'RedHat' and os['release']['major'] == '9'
+        it { is_expected.to contain_yumrepo('libcontainers:stable').with_baseurl => 'https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_9_Stream/'}
+      end
+    end
   end
 end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Under https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/, the urls have moved from `CentOS_9` to `CentOS_9_Stream`. Eg: https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_9_Stream/ and https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/1.26:/1.26.1/CentOS_9_Stream/.

#### This Pull Request (PR) fixes the following issues
When applying to a CentOS 9 machine.
