### PR TITLE
Expose ensure param for container runtime package

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -551,6 +551,7 @@ The following parameters are available in the `k8s::install::container_runtime` 
 * [`containerd_package`](#-k8s--install--container_runtime--containerd_package)
 * [`k8s_version`](#-k8s--install--container_runtime--k8s_version)
 * [`runc_version`](#-k8s--install--container_runtime--runc_version)
+* [`package_ensure`](#-k8s--install--container_runtime--package_ensure)
 
 ##### <a name="-k8s--install--container_runtime--manage_repo"></a>`manage_repo`
 
@@ -599,6 +600,14 @@ Data type: `String[1]`
 the runc version
 
 Default value: `$k8s::runc_version`
+
+##### <a name="-k8s--install--container_runtime--package_ensure"></a>`package_ensure`
+
+Data type: `String[1]`
+
+the ensure value to set on the cri package
+
+Default value: `installed`
 
 ### <a name="k8s--install--crictl"></a>`k8s::install::crictl`
 

--- a/manifests/install/container_runtime.pp
+++ b/manifests/install/container_runtime.pp
@@ -8,6 +8,7 @@
 # @param containerd_package the containerd package anme
 # @param k8s_version the k8s version
 # @param runc_version the runc version
+# @param package_ensure the ensure value to set on the cri package
 #
 class k8s::install::container_runtime (
   Boolean $manage_repo                       = $k8s::manage_repo,
@@ -16,6 +17,7 @@ class k8s::install::container_runtime (
   Optional[String[1]] $containerd_package    = $k8s::containerd_package,
   String[1] $k8s_version                     = $k8s::version,
   String[1] $runc_version                    = $k8s::runc_version,
+  String[1] $package_ensure                  = installed,
 ) {
   case $container_manager {
     'crio': {
@@ -85,7 +87,8 @@ class k8s::install::container_runtime (
   }
 
   package { 'k8s container manager':
-    name => $pkg,
+    ensure => $package_ensure,
+    name   => $pkg,
   }
 
   if $manage_repo {

--- a/spec/classes/install/container_runtime_spec.rb
+++ b/spec/classes/install/container_runtime_spec.rb
@@ -5,7 +5,9 @@ require 'spec_helper'
 describe 'k8s::install::container_runtime' do
   let(:pre_condition) do
     <<~PUPPET
-      include k8s
+      class { 'k8s':
+        manage_container_manager => false,
+      }
     PUPPET
   end
 
@@ -14,6 +16,17 @@ describe 'k8s::install::container_runtime' do
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
+      it { is_expected.to contain_package('k8s container manager') }
+
+      context 'when ensure set' do
+        let(:params) do
+          {
+            package_ensure: '1.26.0'
+          }
+        end
+
+        it { is_expected.to contain_package('k8s container manager').with_ensure('1.26.0') }
+      end
     end
   end
 end


### PR DESCRIPTION
Ran into the requirement to have a more specific CRI version in a few cases, so exposing the ensure parameter to make that particular setup easier to manage.