### PR TITLE
update firewall resources to use jump instead of action; require puppetlabs/firewall 7.x

### DIFF
--- a/manifests/node/kubelet.pp
+++ b/manifests/node/kubelet.pp
@@ -295,9 +295,9 @@ class k8s::node::kubelet (
         include firewall
 
         firewall { '100 allow kubelet access':
-          dport  => 10250,
-          proto  => 'tcp',
-          action => 'accept',
+          dport => 10250,
+          proto => 'tcp',
+          jump  => 'accept',
         }
       }
       default: {}

--- a/manifests/server/apiserver.pp
+++ b/manifests/server/apiserver.pp
@@ -325,9 +325,9 @@ class k8s::server::apiserver (
         include firewall
 
         firewall { '100 allow k8s apiserver access':
-          dport  => 6443,
-          proto  => 'tcp',
-          action => 'accept',
+          dport => 6443,
+          proto => 'tcp',
+          jump  => 'accept',
         }
       }
       default: {}

--- a/manifests/server/etcd.pp
+++ b/manifests/server/etcd.pp
@@ -188,14 +188,14 @@ class k8s::server::etcd (
         include firewall
 
         firewall { '100 allow etcd server access':
-          dport  => 2379,
-          proto  => 'tcp',
-          action => 'accept',
+          dport => 2379,
+          proto => 'tcp',
+          jump  => 'accept',
         }
         firewall { '100 allow etcd client access':
-          dport  => 2380,
-          proto  => 'tcp',
-          action => 'accept',
+          dport => 2380,
+          proto => 'tcp',
+          jump  => 'accept',
         }
       }
       default: {}

--- a/metadata.json
+++ b/metadata.json
@@ -30,7 +30,7 @@
     },
     {
       "name": "puppetlabs-firewall",
-      "version_requirement": ">= 4.0.0 < 7.0.0"
+      "version_requirement": ">= 7.0.0 < 8.0.0"
     },
     {
       "name": "puppet-firewalld",


### PR DESCRIPTION
with puppetlabs/firewall 7.0.0 the parameter was renamed from **action** to **jump**