### PR TITLE
Do not allow bootstrap tokens with a trailing newline

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -4105,7 +4105,7 @@ The index of the IP to retrieve
 
 A Kubernetes bootstrap token, must be 16-characters lowercase alphanumerical
 
-Alias of `Pattern[/^[a-z0-9]{16}$/]`
+Alias of `Pattern[/^[a-z0-9]{16}\z/]`
 
 ### <a name="K8s--CIDR"></a>`K8s::CIDR`
 

--- a/types/bootstrap_token.pp
+++ b/types/bootstrap_token.pp
@@ -1,2 +1,2 @@
 # @summary A Kubernetes bootstrap token, must be 16-characters lowercase alphanumerical
-type K8s::Bootstrap_token = Pattern[/^[a-z0-9]{16}$/]
+type K8s::Bootstrap_token = Pattern[/^[a-z0-9]{16}\z/]


### PR DESCRIPTION
#### Pull Request (PR) description
The regex used to validate the bootstrap token allows strings that end with a newline. 

This PR makes the regex more strict by using `\z` instead of `$` to match the end of the string. (`\z` does not allow trailing newline characters).

#### This Pull Request (PR) fixes the following issues
When the bootstrap token contains a newline, worker nodes fail to join the cluster. The `kubelet` process  emit strange errors like:
```
kubelet[10895]: E0130 14:00:33.287321   10895 certificate_manager.go:562] kubernetes.io/kube-apiserver-client-kubelet: Failed while requesting a signed certificate from the control plane: cannot create certificate signing request: Post "https://kubernetes.vagrant.local:6443/apis/certificates.k8s.io/v1/certificatesigningrequests": net/http: invalid header field value for "Authorization"
kubelet[10895]: E0130 14:00:33.616337   10895 kubelet_node_status.go:96] "Unable to register node with API server" err="nodes is forbidden: User \"system:anonymous\" cannot create resource \"nodes\" in API group \"\" at the cluster scope
kubelet[10895]: E0130 14:00:45.972707   10895 controller.go:145] "Failed to ensure lease exists, will retry" err="leases.coordination.k8s.io \"vagrant-k8s-k8s-worker1\" is forbidden: User \"system:anonymous\" cannot get resource \"leases\" in API group \"coordination.k8s.io\" in the namespace \"kube-node-lease\"" interval="7s"
kubelet[10895]: W0130 14:00:50.253971   10895 reflector.go:539] vendor/k8s.io/client-go/informers/factory.go:159: failed to list *v1.Node: nodes "vagrant-k8s-k8s-worker1" is forbidden: User "system:anonymous" cannot list resource "nodes" in API group "" at the cluster scope
```