### PR TITLE
Do not allow bootstrap tokens with a leading newline

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -4105,7 +4105,7 @@ The index of the IP to retrieve
 
 A Kubernetes bootstrap token, must be 16-characters lowercase alphanumerical
 
-Alias of `Pattern[/^[a-z0-9]{16}\z/]`
+Alias of `Pattern[/\A[a-z0-9]{16}\z/]`
 
 ### <a name="K8s--CIDR"></a>`K8s::CIDR`
 

--- a/types/bootstrap_token.pp
+++ b/types/bootstrap_token.pp
@@ -1,2 +1,2 @@
 # @summary A Kubernetes bootstrap token, must be 16-characters lowercase alphanumerical
-type K8s::Bootstrap_token = Pattern[/^[a-z0-9]{16}\z/]
+type K8s::Bootstrap_token = Pattern[/\A[a-z0-9]{16}\z/]


### PR DESCRIPTION
#### Pull Request (PR) description
Follow up to https://github.com/voxpupuli/puppet-k8s/pull/79.

#### This Pull Request (PR) fixes the following issues
Fixes the same issue as https://github.com/voxpupuli/puppet-k8s/pull/79, but for the case when the bootstrap token starts with a newline character.
