### PR TITLE
Make cni_plugins download url configurable with a template string

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -499,18 +499,10 @@ Class: k8s::install::cni_plugins
 
 The following parameters are available in the `k8s::install::cni_plugins` class:
 
-* [`arch`](#-k8s--install--cni_plugins--arch)
 * [`ensure`](#-k8s--install--cni_plugins--ensure)
 * [`method`](#-k8s--install--cni_plugins--method)
 * [`version`](#-k8s--install--cni_plugins--version)
-
-##### <a name="-k8s--install--cni_plugins--arch"></a>`arch`
-
-Data type: `String[1]`
-
-sets the arch to use for binary download
-
-Default value: `'amd64'`
+* [`download_url_template`](#-k8s--install--cni_plugins--download_url_template)
 
 ##### <a name="-k8s--install--cni_plugins--ensure"></a>`ensure`
 
@@ -535,6 +527,14 @@ Data type: `String[1]`
 sets the version to use
 
 Default value: `'v1.2.0'`
+
+##### <a name="-k8s--install--cni_plugins--download_url_template"></a>`download_url_template`
+
+Data type: `String[1]`
+
+template string for the cni_plugins download url
+
+Default value: `'https://github.com/containernetworking/plugins/releases/download/%{version}/cni-plugins-linux-%{arch}-%{version}.tgz'`
 
 ### <a name="k8s--install--container_runtime"></a>`k8s::install::container_runtime`
 


### PR DESCRIPTION
#### Pull Request (PR) description
This PR makes the download URL for the CNI plugins configurable by adding a new parameter to the `cni_plugins` class. The parameter is a template string, which is rendered using the `k8s::format_url` function. 

NOTE: The `k8s::format_url` function auto-detects the CPU architecture, so the `arch` parameter is no longer required. I am therefore removing it from the class. This could be a breaking change if users have set `arch` to something other than their system's actual CPU architecture. I don't think anyone is doing that though, since you would end up installing the k8s binaries for one architecture and the cni plugins for another.

#### This Pull Request (PR) fixes the following issues
The download URL is currently hard-coded to github.com. This makes it difficult to use the module in air-gapped environments.
