### PR TITLE
Use a template string for the crictl download URL

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -618,11 +618,10 @@ The following parameters are available in the `k8s::install::crictl` class:
 
 * [`ensure`](#-k8s--install--crictl--ensure)
 * [`version`](#-k8s--install--crictl--version)
-* [`arch`](#-k8s--install--crictl--arch)
 * [`config`](#-k8s--install--crictl--config)
 * [`crictl_package`](#-k8s--install--crictl--crictl_package)
 * [`manage_repo`](#-k8s--install--crictl--manage_repo)
-* [`download_url`](#-k8s--install--crictl--download_url)
+* [`download_url_template`](#-k8s--install--crictl--download_url_template)
 
 ##### <a name="-k8s--install--crictl--ensure"></a>`ensure`
 
@@ -639,14 +638,6 @@ Data type: `String[1]`
 the k8s version
 
 Default value: `'v1.26.0'`
-
-##### <a name="-k8s--install--crictl--arch"></a>`arch`
-
-Data type: `String[1]`
-
-os architecture
-
-Default value: `'amd64'`
 
 ##### <a name="-k8s--install--crictl--config"></a>`config`
 
@@ -675,13 +666,13 @@ whether to manage the repo or not
 
 Default value: `$k8s::manage_repo`
 
-##### <a name="-k8s--install--crictl--download_url"></a>`download_url`
+##### <a name="-k8s--install--crictl--download_url_template"></a>`download_url_template`
 
 Data type: `Stdlib::HTTPUrl`
 
-where to download the tar.gz from
+template string for the URL to download tar.gz from
 
-Default value: `"https://github.com/kubernetes-sigs/cri-tools/releases/download/${version}/crictl-${version}-linux-${arch}.tar.gz"`
+Default value: `'https://github.com/kubernetes-sigs/cri-tools/releases/download/%{version}/crictl-%{version}-linux-%{arch}.tar.gz'`
 
 ### <a name="k8s--install--kubeadm"></a>`k8s::install::kubeadm`
 

--- a/manifests/install/crictl.pp
+++ b/manifests/install/crictl.pp
@@ -4,23 +4,21 @@
 #
 # @param ensure set ensure for installation or deinstallation
 # @param version the k8s version
-# @param arch os architecture
 # @param config config for crictl, for example:
 #   k8s::install::crictl::config:
 #     'runtime-endpoint': 'unix:///run/containerd/containerd.sock'
 #     'image-endpoint': 'unix:///run/containerd/containerd.sock'
 # @param crictl_package the package name of crictl
 # @param manage_repo whether to manage the repo or not
-# @param download_url where to download the tar.gz from
+# @param download_url_template template string for the URL to download tar.gz from
 #
 class k8s::install::crictl (
-  Boolean $manage_repo                = $k8s::manage_repo,
-  Hash $config                        = {},
-  K8s::Ensure $ensure                 = $k8s::ensure,
-  Optional[String[1]] $crictl_package = $k8s::crictl_package,
-  String[1] $arch                     = 'amd64',
-  String[1] $version                  = 'v1.26.0',
-  Stdlib::HTTPUrl $download_url       = "https://github.com/kubernetes-sigs/cri-tools/releases/download/${version}/crictl-${version}-linux-${arch}.tar.gz",
+  Boolean $manage_repo                   = $k8s::manage_repo,
+  Hash $config                           = {},
+  K8s::Ensure $ensure                    = $k8s::ensure,
+  Optional[String[1]] $crictl_package    = $k8s::crictl_package,
+  String[1] $version                     = 'v1.26.0',
+  Stdlib::HTTPUrl $download_url_template = 'https://github.com/kubernetes-sigs/cri-tools/releases/download/%{version}/crictl-%{version}-linux-%{arch}.tar.gz',
 ) {
   if $manage_repo {
     $pkg = pick($crictl_package, 'cri-tools')
@@ -33,10 +31,14 @@ class k8s::install::crictl (
 
     $config_require = Package[$pkg]
   } else {
+    $_url = k8s::format_url($download_url_template, {
+        version => $version,
+    })
+
     archive { 'crictl':
       ensure       => $ensure,
-      path         => "/tmp/crictl-${version}-linux-${arch}.tar.gz",
-      source       => $download_url,
+      path         => "/tmp/crictl-${version}-linux.tar.gz",
+      source       => $_url,
       extract      => true,
       extract_path => '/usr/local/bin',
       creates      => '/usr/local/bin/crictl',


### PR DESCRIPTION
#### Pull Request (PR) description
This PR replaces the `download_url` parameter of the `crictl` class with a new parameter called `download_url_template`. This parameter uses template variables and is rendered using the `k8s::format_url` function, similar to how other download URLs are handled in this module. 

The k8s::format_url function auto-detects the CPU architecture, so the arch parameter is no longer required. I am therefore removing it from the class.

NOTE: This is a breaking change for users that use the `download_url` parameter. Should this be noted somewhere?

#### This Pull Request (PR) fixes the following issues
Without templating, it is cumbersome to override the download URL. The user has to handle the version and arch themselves. It is also inconsistent with other parts of the module that use templating for download URLs.