### PR TITLE
kubectl_apply: add missing require

### DIFF
--- a/lib/puppet/type/kubectl_apply.rb
+++ b/lib/puppet/type/kubectl_apply.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'puppet/parameter/boolean'
+
 Puppet::Type.newtype(:kubectl_apply) do
   desc <<-DOC
   Example:


### PR DESCRIPTION
#### Pull Request (PR) description
puppet generate types fails with
```
Failed to load custom type 'kubectl_apply' from '/etc/puppetlabs/code/environments/test/modules/k8s/lib/puppet/type/kubectl_apply.rb': uninitialized constant Puppet::Parameter::Boolean
```

Adding `require 'puppet/parameter/boolean'` to kubectl_apply type.
