### PR TITLE
Update k8s/cri-o repositories

### DIFF
--- a/manifests/install/container_runtime.pp
+++ b/manifests/install/container_runtime.pp
@@ -21,51 +21,7 @@ class k8s::install::container_runtime (
 ) {
   case $container_manager {
     'crio': {
-      if fact('os.family') == 'Debian' {
-        $_crio_version = $k8s_version.split('\.')[0, 2].join('.')
-        if versioncmp($_crio_version, '1.17') < 0 {
-          $pkg = pick($crio_package, "cri-o-${_crio_version}")
-        } else {
-          $pkg = pick($crio_package, 'cri-o')
-        }
-
-        # This is needed by cri-o, but it is not a dependency of the package
-        package { 'runc':
-          ensure => $runc_version,
-        }
-
-        # Avoid a potential issue with some CRI-o versions
-        file { ['/usr/lib/cri-o-runc/sbin', '/usr/lib/cri-o-runc']:
-          ensure => directory,
-        }
-
-        file { '/usr/lib/cri-o-runc/sbin/runc':
-          ensure  => link,
-          target  => '/usr/sbin/runc',
-          replace => false,
-        }
-      } else {
-        $pkg = pick($crio_package, 'cri-o')
-      }
-
-      file { '/usr/libexec/crio/conmon':
-        ensure  => link,
-        target  => '/usr/bin/conmon',
-        replace => false,
-        require => Package['k8s container manager'],
-      }
-
-      file { '/etc/cni/net.d/100-crio-bridge.conf':
-        ensure  => absent,
-        require => Package['k8s container manager'],
-      }
-
-      file_line { 'K8s crio cgroup manager':
-        path    => '/etc/crio/crio.conf',
-        line    => 'cgroup_manager = "systemd"',
-        match   => '^cgroup_manager',
-        require => Package['k8s container manager'],
-      }
+      $pkg = pick($crio_package, 'cri-o')
     }
     'containerd': {
       file { '/etc/containerd':

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -8,16 +8,13 @@ class k8s::repo (
   Boolean $manage_container_manager          = $k8s::manage_container_manager,
   K8s::Container_runtimes $container_manager = $k8s::container_manager,
   String[1] $crio_version                    = $k8s::version.split('\.')[0, 2].join('.'),
+  Boolean $use_kubic_repos                   = false
 ) {
   case fact('os.family') {
     'Debian': {
       case fact('os.name') {
         'Debian': {
-          if versioncmp($crio_version, '1.19') >= 0 {
-            $release_name = "Debian_${fact('os.release.major')}"
-          } else {
-            $release_name = 'Debian_Testing'
-          }
+          $release_name = "Debian_${fact('os.release.major')}"
         }
         'Ubuntu': {
           $release_name = "xUbuntu_${fact('os.release.full')}"
@@ -28,26 +25,39 @@ class k8s::repo (
         default: {}
       }
 
-      $libcontainers_url = "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/${release_name}"
-      $crio_url          = "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/${crio_version}/${release_name}"
+      if $use_kubic_repos {
+        $kubernames_name = 'libcontainers:stable'
+        $kubernames_repo = "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/${release_name}"
+        $kubernetes_key  = '2472D6D0D2F66AF87ABA8DA34D64390375060AA4',
+        $crio_name       = 'libcontainers:stable:cri-o'
+        $crio_url        = "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/${crio_version}/${release_name}"
+        $crio_key        = '2472D6D0D2F66AF87ABA8DA34D64390375060AA4',
+      } else {
+        $kubernetes_name = 'kubernetes'
+        $kubernetes_repo = "https://pkgs.k8s.io/core:/stable:/v${crio_version}/deb"
+        $kubernetes_key  = 'kubernetes-apt-keyring.gpg'
+        $crio_name       = 'cri-o'
+        $crio_url        = "https://pkgs.k8s.io/addons:/cri-o:/stable:/v${crio_version}/deb"
+        $crio_key        = 'cri-o-apt-keyring.gpg'
+      }
 
-      apt::source { 'libcontainers:stable':
-        location => $libcontainers_url,
+      apt::source { $kubernames_name:
+        location => $kubernetes_repo,
         repos    => '/',
         release  => '',
         key      => {
-          id     => '2472D6D0D2F66AF87ABA8DA34D64390375060AA4',
-          source => "${libcontainers_url}/Release.key",
+          name   => $kubernetes_key,
+          source => "${kubernetes_repo}/Release.key",
         },
       }
 
       if $manage_container_manager and $container_manager == 'crio' {
-        apt::source { 'libcontainers:stable:cri-o':
+        apt::source { $crio_name:
           location => $crio_url,
           repos    => '/',
           release  => '',
           key      => {
-            id     => '2472D6D0D2F66AF87ABA8DA34D64390375060AA4',
+            name   => $crio_key,
             source => "${crio_url}/Release.key",
           },
         }


### PR DESCRIPTION
#### Pull Request (PR) description

* Remove obsolete path fixes that don't exist in any version of crio packages I can find
* Remove conditionals around long-obsolete/unsupported versions
* Allow use of the deprecated kubic repos, default to official k8s packages

#### This Pull Request (PR) fixes the following issues

Fixes #77
Fixes #47 (for Ubuntu)

#### Some comments

I included the ability to use the kubic repos for existing implementations (with a value change) based on this comment https://github.com/voxpupuli/puppet-k8s/issues/77#issuecomment-1902675050 however given the number of changes around k8s repos since 1.28 I personally think it would be better to make a major version cut and simply say that it drops support for the kubic repos which are deprecated IMHO YMMV

Obviously this PR only addresses Debian. I didn't want to invest the time until we have some consensus on the approach, at which time I'll update the PR to fix the repos for all platforms.