### PR TITLE
Unpack cni_plugins, crictl & etcd to folders in /opt and use symlinks

### DIFF
--- a/manifests/install/cni_plugins.pp
+++ b/manifests/install/cni_plugins.pp
@@ -24,27 +24,14 @@ class k8s::install::cni_plugins (
 
   case $method {
     'tarball', 'loose': {
-      file { '/opt/cni-plugins':
-        ensure  => stdlib::ensure($ensure, 'directory'),
-        purge   => true,
-        recurse => true,
-        force   => true,
-      }
-
       $_url = k8s::format_url($download_url_template, {
           version => $version,
       })
-      $_target = "/opt/cni-plugins/${version}";
-      $_tarball_target = '/opt/cni-plugins/archives';
+      $_target = "/opt/k8s/cni-${version}";
+      $_tarball_target = '/opt/k8s/archives';
 
       file { $_target:
         ensure  => stdlib::ensure($ensure, 'directory'),
-      }
-
-      file { $_tarball_target:
-        ensure  => stdlib::ensure($ensure, 'directory'),
-        purge   => true,
-        recurse => true,
       }
 
       archive { 'cni-plugins':

--- a/manifests/install/crictl.pp
+++ b/manifests/install/crictl.pp
@@ -31,24 +31,13 @@ class k8s::install::crictl (
 
     $config_require = Package[$pkg]
   } else {
-    file { '/opt/cri-tools':
-      ensure  => stdlib::ensure($ensure, 'directory'),
-      purge   => true,
-      recurse => true,
-      force   => true,
-    }
-
     $_url = k8s::format_url($download_url_template, {
         version => $version,
     })
-    $_target = "/opt/cri-tools/${version}";
-    $_tarball_target = '/opt/cri-tools/archives';
+    $_target = "/opt/k8s/crictl-${version}";
+    $_tarball_target = '/opt/k8s/archives';
 
     file { $_target:
-      ensure  => stdlib::ensure($ensure, 'directory'),
-    }
-
-    file { $_tarball_target:
       ensure  => stdlib::ensure($ensure, 'directory'),
     }
 

--- a/manifests/server/etcd/setup.pp
+++ b/manifests/server/etcd/setup.pp
@@ -78,23 +78,12 @@ class k8s::server::etcd::setup (
   Optional[Integer[0, 65535]] $gid        = undef,
 ) {
   if $install == 'archive' {
-    file { '/opt/etcd':
-      ensure  => stdlib::ensure($ensure, 'directory'),
-      purge   => true,
-      recurse => true,
-      force   => true,
-    }
-
     $_url  = k8s::format_url($archive_template, { version => $version, })
     $_file = basename($_url)
-    $_target = "/opt/etcd/${version}";
-    $_tarball_target = '/opt/etcd/archives';
+    $_target = "/opt/k8s/etcd-${version}";
+    $_tarball_target = '/opt/k8s/archives';
 
     file { $_target:
-      ensure  => stdlib::ensure($ensure, 'directory'),
-    }
-
-    file { $_tarball_target:
       ensure  => stdlib::ensure($ensure, 'directory'),
     }
 

--- a/manifests/server/etcd/setup.pp
+++ b/manifests/server/etcd/setup.pp
@@ -78,24 +78,52 @@ class k8s::server::etcd::setup (
   Optional[Integer[0, 65535]] $gid        = undef,
 ) {
   if $install == 'archive' {
+    file { '/opt/etcd':
+      ensure  => stdlib::ensure($ensure, 'directory'),
+      purge   => true,
+      recurse => true,
+      force   => true,
+    }
+
     $_url  = k8s::format_url($archive_template, { version => $version, })
     $_file = basename($_url)
+    $_target = "/opt/etcd/${version}";
+    $_tarball_target = '/opt/etcd/archives';
 
-    archive { "/var/tmp/${_file}":
+    file { $_target:
+      ensure  => stdlib::ensure($ensure, 'directory'),
+    }
+
+    file { $_tarball_target:
+      ensure  => stdlib::ensure($ensure, 'directory'),
+    }
+
+    archive { 'etcd':
       ensure          => $ensure,
+      path            => "${_tarball_target}/${_file}",
       source          => $_url,
       extract         => true,
       extract_command => 'tar xfz %s --strip-components=1',
-      extract_path    => '/usr/local/bin',
+      extract_path    => $_target,
       cleanup         => true,
-      creates         => ['/usr/local/bin/etcd', '/usr/local/bin/etcdctl'],
-      notify          => Service['etcd'],
+      creates         => ["${_target}/etcd", "${_target}/etcdctl"],
     }
 
-    if $ensure == 'absent' {
-      file { ['/usr/local/bin/etcd', '/usr/local/bin/etcdctl']:
-        ensure => 'absent',
-      }
+    file { '/usr/local/bin/etcd':
+      ensure  => stdlib::ensure($ensure, 'link'),
+      mode    => '0755',
+      replace => true,
+      target  => "${_target}/etcd",
+      require => Archive['etcd'],
+      notify  => Service['etcd'],
+    }
+
+    file { '/usr/local/bin/etcdctl':
+      ensure  => stdlib::ensure($ensure, 'link'),
+      mode    => '0755',
+      replace => true,
+      target  => "${_target}/etcdctl",
+      require => Archive['etcd'],
     }
 
     group { $group:

--- a/spec/classes/server/etcd/setup_spec.rb
+++ b/spec/classes/server/etcd/setup_spec.rb
@@ -31,15 +31,30 @@ describe 'k8s::server::etcd::setup' do
       it { is_expected.to compile }
 
       it do
-        is_expected.to contain_archive('/var/tmp/etcd-v3.6.0-linux-amd64.tar.gz').with(
+        is_expected.to contain_archive('etcd').with(
           ensure: 'present',
+          path: '/opt/etcd/archives/etcd-v3.6.0-linux-amd64.tar.gz',
           source: 'https://storage.googleapis.com/etcd/v3.6.0/etcd-v3.6.0-linux-amd64.tar.gz',
           extract: true,
           extract_command: 'tar xfz %s --strip-components=1',
-          extract_path: '/usr/local/bin',
+          extract_path: '/opt/etcd/3.6.0',
           cleanup: true,
-          creates: ['/usr/local/bin/etcd', '/usr/local/bin/etcdctl']
+          creates: ['/opt/etcd/3.6.0/etcd', '/opt/etcd/3.6.0/etcdctl']
+        )
+
+        is_expected.to contain_file('/usr/local/bin/etcd').with(
+          ensure: 'link',
+          mode: '0755',
+          replace: true,
+          target: '/opt/etcd/3.6.0/etcd'
         ).that_notifies('Service[etcd]')
+
+        is_expected.to contain_file('/usr/local/bin/etcdctl').with(
+          ensure: 'link',
+          mode: '0755',
+          replace: true,
+          target: '/opt/etcd/3.6.0/etcdctl'
+        )
       end
 
       it { is_expected.to contain_user('etcd') }

--- a/spec/classes/server/etcd/setup_spec.rb
+++ b/spec/classes/server/etcd/setup_spec.rb
@@ -33,27 +33,27 @@ describe 'k8s::server::etcd::setup' do
       it do
         is_expected.to contain_archive('etcd').with(
           ensure: 'present',
-          path: '/opt/etcd/archives/etcd-v3.6.0-linux-amd64.tar.gz',
+          path: '/opt/k8s/archives/etcd-v3.6.0-linux-amd64.tar.gz',
           source: 'https://storage.googleapis.com/etcd/v3.6.0/etcd-v3.6.0-linux-amd64.tar.gz',
           extract: true,
           extract_command: 'tar xfz %s --strip-components=1',
-          extract_path: '/opt/etcd/3.6.0',
+          extract_path: '/opt/k8s/etcd-3.6.0',
           cleanup: true,
-          creates: ['/opt/etcd/3.6.0/etcd', '/opt/etcd/3.6.0/etcdctl']
+          creates: ['/opt/k8s/etcd-3.6.0/etcd', '/opt/k8s/etcd-3.6.0/etcdctl']
         )
 
         is_expected.to contain_file('/usr/local/bin/etcd').with(
           ensure: 'link',
           mode: '0755',
           replace: true,
-          target: '/opt/etcd/3.6.0/etcd'
+          target: '/opt/k8s/etcd-3.6.0/etcd'
         ).that_notifies('Service[etcd]')
 
         is_expected.to contain_file('/usr/local/bin/etcdctl').with(
           ensure: 'link',
           mode: '0755',
           replace: true,
-          target: '/opt/etcd/3.6.0/etcdctl'
+          target: '/opt/k8s/etcd-3.6.0/etcdctl'
         )
       end
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Makes the installation of cni_plugins, crictl & etcd similar to the way the main k8s binaries are installed. The archives are unpacked to folders in /opt and symlinked to /usr/local/bin . The target folder is unique per version, making it possible to update these components.

#### This Pull Request (PR) fixes the following issues

Fixes #95.
