### PR TITLE
Update binary repos and versions to support modern Kubernetes

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -249,7 +249,7 @@ Data type: `String[1]`
 
 version of etcd to install
 
-Default value: `'3.5.1'`
+Default value: `'3.5.16'`
 
 ##### <a name="-k8s--firewall_type"></a>`firewall_type`
 
@@ -377,7 +377,7 @@ Data type: `String[1]`
 
 template for native packaging
 
-Default value: `'https://storage.googleapis.com/kubernetes-release/release/v%{version}/bin/%{kernel}/%{arch}/%{binary}'`
+Default value: `'https://dl.k8s.io/release/v%{version}/bin/%{kernel}/%{arch}/%{binary}'`
 
 ##### <a name="-k8s--node_auth"></a>`node_auth`
 
@@ -465,7 +465,7 @@ Data type: `String[1]`
 
 template for tarball packaging
 
-Default value: `'https://dl.k8s.io/v%{version}/kubernetes-%{component}-%{kernel}-%{arch}.tar.gz'`
+Default value: `'https://dl.k8s.io/release/v%{version}/kubernetes-%{component}-%{kernel}-%{arch}.tar.gz'`
 
 ##### <a name="-k8s--uid"></a>`uid`
 
@@ -489,7 +489,7 @@ Data type: `String[1]`
 
 version of kubernetes to install
 
-Default value: `'1.26.1'`
+Default value: `'1.28.14'`
 
 ### <a name="k8s--install--cni_plugins"></a>`k8s::install::cni_plugins`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -78,7 +78,7 @@ class k8s (
 
   Boolean $purge_manifests = true,
 
-  String[1] $native_url_template             = 'https://dl.k8s.io/release/v%{version}/bin/%{kernel}/%{arch}/%{binary}'
+  String[1] $native_url_template             = 'https://dl.k8s.io/release/v%{version}/bin/%{kernel}/%{arch}/%{binary}',
   String[1] $tarball_url_template            = 'https://dl.k8s.io/release/v%{version}/kubernetes-%{component}-%{kernel}-%{arch}.tar.gz',
   String[1] $package_template                = 'kubernetes-%{component}',
   String[1] $hyperkube_name                  = 'hyperkube',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,8 +50,8 @@ class k8s (
   K8s::Ensure $ensure                     = 'present',
   Enum['container', 'native'] $packaging  = 'native',
   K8s::Native_packaging $native_packaging = 'loose',
-  String[1] $version                      = '1.26.1',
-  String[1] $etcd_version                 = '3.5.1',
+  String[1] $version                      = '1.28.14',
+  String[1] $etcd_version                 = '3.5.16',
 
   String[1] $container_registry              = 'registry.k8s.io',
   Optional[String[1]] $container_image_tag   = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -78,8 +78,8 @@ class k8s (
 
   Boolean $purge_manifests = true,
 
-  String[1] $native_url_template             = 'https://storage.googleapis.com/kubernetes-release/release/v%{version}/bin/%{kernel}/%{arch}/%{binary}',
-  String[1] $tarball_url_template            = 'https://dl.k8s.io/v%{version}/kubernetes-%{component}-%{kernel}-%{arch}.tar.gz',
+  String[1] $native_url_template             = 'https://dl.k8s.io/release/v%{version}/bin/%{kernel}/%{arch}/%{binary}'
+  String[1] $tarball_url_template            = 'https://dl.k8s.io/release/v%{version}/kubernetes-%{component}-%{kernel}-%{arch}.tar.gz',
   String[1] $package_template                = 'kubernetes-%{component}',
   String[1] $hyperkube_name                  = 'hyperkube',
   Optional[Stdlib::Unixpath] $sysconfig_path = undef,

--- a/spec/defines/binary_spec.rb
+++ b/spec/defines/binary_spec.rb
@@ -68,7 +68,7 @@ describe 'k8s::binary' do
                   is_expected.to contain_file("/opt/k8s/1.0/#{binary}").with(
                     ensure: 'present',
                     mode: '0755',
-                    source: "https://storage.googleapis.com/kubernetes-release/release/v1.0/bin/linux/amd64/#{binary}"
+                    source: "https://dl.k8s.io/release/v1.0/bin/linux/amd64/#{binary}"
                   )
                 end
               when 'hyperkube'
@@ -76,7 +76,7 @@ describe 'k8s::binary' do
                   is_expected.to contain_file('/opt/k8s/1.0/hyperkube').with(
                     ensure: 'present',
                     mode: '0755',
-                    source: 'https://storage.googleapis.com/kubernetes-release/release/v1.0/bin/linux/amd64/hyperkube'
+                    source: 'https://dl.k8s.io/release/v1.0/bin/linux/amd64/hyperkube'
                   )
                 end
               end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Updates the URL templates to use the new `dl.k8s.io` store instead of the older `storage.googleapis.com` one.
This also includes a bump to a non-EoL version of Kubernetes, one where the binaries are guaranteed to exist.

#### This Pull Request (PR) fixes the following issues

Fixes #100
