### PR TITLE
Use pkgs.k8s.io repos instead of kubic

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -503,6 +503,7 @@ The following parameters are available in the `k8s::install::cni_plugins` class:
 * [`method`](#-k8s--install--cni_plugins--method)
 * [`version`](#-k8s--install--cni_plugins--version)
 * [`download_url_template`](#-k8s--install--cni_plugins--download_url_template)
+* [`package_name`](#-k8s--install--cni_plugins--package_name)
 
 ##### <a name="-k8s--install--cni_plugins--ensure"></a>`ensure`
 
@@ -535,6 +536,14 @@ Data type: `String[1]`
 template string for the cni_plugins download url
 
 Default value: `'https://github.com/containernetworking/plugins/releases/download/%{version}/cni-plugins-linux-%{arch}-%{version}.tgz'`
+
+##### <a name="-k8s--install--cni_plugins--package_name"></a>`package_name`
+
+Data type: `Optional[String[1]]`
+
+
+
+Default value: `undef`
 
 ### <a name="k8s--install--container_runtime"></a>`k8s::install::container_runtime`
 
@@ -1252,6 +1261,7 @@ The following parameters are available in the `k8s::repo` class:
 * [`container_manager`](#-k8s--repo--container_manager)
 * [`crio_version`](#-k8s--repo--crio_version)
 * [`manage_container_manager`](#-k8s--repo--manage_container_manager)
+* [`major_version`](#-k8s--repo--major_version)
 
 ##### <a name="-k8s--repo--container_manager"></a>`container_manager`
 
@@ -1263,11 +1273,7 @@ Default value: `$k8s::container_manager`
 
 ##### <a name="-k8s--repo--crio_version"></a>`crio_version`
 
-Data type: `String[1]`
-
 version o cri-o
-
-Default value: `$k8s::version.split('\.')[0, 2].join('.')`
 
 ##### <a name="-k8s--repo--manage_container_manager"></a>`manage_container_manager`
 
@@ -1276,6 +1282,14 @@ Data type: `Boolean`
 whether to add cri-o repository or not
 
 Default value: `$k8s::manage_container_manager`
+
+##### <a name="-k8s--repo--major_version"></a>`major_version`
+
+Data type: `String[1]`
+
+
+
+Default value: `$k8s::version.split('\.')[0, 2].join('.')`
 
 ### <a name="k8s--server"></a>`k8s::server`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -7,8 +7,8 @@
 ### Classes
 
 * [`k8s`](#k8s): Sets up a Kubernetes instance - either as a node or as a server
-* [`k8s::install::cni_plugins`](#k8s--install--cni_plugins): manages the installation of the cni plugins
-* [`k8s::install::container_runtime`](#k8s--install--container_runtime): manages the installation of cri
+* [`k8s::install::cni_plugins`](#k8s--install--cni_plugins): Manages the installation of CNI plugins
+* [`k8s::install::container_runtime`](#k8s--install--container_runtime): Manages the installation of a container runtime / CRI
 * [`k8s::install::crictl`](#k8s--install--crictl): installs the crictl debugging tool
 * [`k8s::install::kubeadm`](#k8s--install--kubeadm): Installs the kubeadm binary
 * [`k8s::install::kubectl`](#k8s--install--kubectl): Installs the kubectl binary
@@ -493,7 +493,7 @@ Default value: `'1.28.14'`
 
 ### <a name="k8s--install--cni_plugins"></a>`k8s::install::cni_plugins`
 
-Class: k8s::install::cni_plugins
+Manages the installation of CNI plugins
 
 #### Parameters
 
@@ -509,7 +509,7 @@ The following parameters are available in the `k8s::install::cni_plugins` class:
 
 Data type: `K8s::Ensure`
 
-set ensure for installation or deinstallation
+Set ensure for installation or deinstallation
 
 Default value: `$k8s::ensure`
 
@@ -517,7 +517,7 @@ Default value: `$k8s::ensure`
 
 Data type: `String[1]`
 
-installation method
+The installation method to use
 
 Default value: `$k8s::native_packaging`
 
@@ -525,7 +525,7 @@ Default value: `$k8s::native_packaging`
 
 Data type: `String[1]`
 
-sets the version to use
+The version of CNI plugins to install - if applicable
 
 Default value: `'v1.2.0'`
 
@@ -533,7 +533,7 @@ Default value: `'v1.2.0'`
 
 Data type: `String[1]`
 
-template string for the cni_plugins download url
+Template string for the cni_plugins download url
 
 Default value: `'https://github.com/containernetworking/plugins/releases/download/%{version}/cni-plugins-linux-%{arch}-%{version}.tgz'`
 
@@ -541,81 +541,72 @@ Default value: `'https://github.com/containernetworking/plugins/releases/downloa
 
 Data type: `Optional[String[1]]`
 
-
+Package name for the CNI plugins, will use OS default if omitted
 
 Default value: `undef`
 
 ### <a name="k8s--install--container_runtime"></a>`k8s::install::container_runtime`
 
-Class: k8s::install::container_runtime
+Manages the installation of a container runtime / CRI
 
 #### Parameters
 
 The following parameters are available in the `k8s::install::container_runtime` class:
 
-* [`container_manager`](#-k8s--install--container_runtime--container_manager)
-* [`containerd_package`](#-k8s--install--container_runtime--containerd_package)
-* [`crio_package`](#-k8s--install--container_runtime--crio_package)
-* [`k8s_version`](#-k8s--install--container_runtime--k8s_version)
 * [`manage_repo`](#-k8s--install--container_runtime--manage_repo)
-* [`package_ensure`](#-k8s--install--container_runtime--package_ensure)
+* [`container_manager`](#-k8s--install--container_runtime--container_manager)
+* [`crio_package`](#-k8s--install--container_runtime--crio_package)
+* [`containerd_package`](#-k8s--install--container_runtime--containerd_package)
 * [`runc_version`](#-k8s--install--container_runtime--runc_version)
-
-##### <a name="-k8s--install--container_runtime--container_manager"></a>`container_manager`
-
-Data type: `K8s::Container_runtimes`
-
-set the cri to use
-
-Default value: `$k8s::container_manager`
-
-##### <a name="-k8s--install--container_runtime--containerd_package"></a>`containerd_package`
-
-Data type: `Optional[String[1]]`
-
-the containerd package anme
-
-Default value: `$k8s::containerd_package`
-
-##### <a name="-k8s--install--container_runtime--crio_package"></a>`crio_package`
-
-Data type: `Optional[String[1]]`
-
-cri-o the package name
-
-Default value: `$k8s::crio_package`
-
-##### <a name="-k8s--install--container_runtime--k8s_version"></a>`k8s_version`
-
-Data type: `String[1]`
-
-the k8s version
-
-Default value: `$k8s::version`
+* [`package_ensure`](#-k8s--install--container_runtime--package_ensure)
 
 ##### <a name="-k8s--install--container_runtime--manage_repo"></a>`manage_repo`
 
 Data type: `Boolean`
 
-whether to manage the repo or not
+Whether to manage the repo or not
 
 Default value: `$k8s::manage_repo`
 
-##### <a name="-k8s--install--container_runtime--package_ensure"></a>`package_ensure`
+##### <a name="-k8s--install--container_runtime--container_manager"></a>`container_manager`
 
-Data type: `String[1]`
+Data type: `K8s::Container_runtimes`
 
-the ensure value to set on the cri package
+The CRI implementation to install
 
-Default value: `installed`
+Default value: `$k8s::container_manager`
+
+##### <a name="-k8s--install--container_runtime--crio_package"></a>`crio_package`
+
+Data type: `Optional[String[1]]`
+
+The CRI-o package name
+
+Default value: `$k8s::crio_package`
+
+##### <a name="-k8s--install--container_runtime--containerd_package"></a>`containerd_package`
+
+Data type: `Optional[String[1]]`
+
+The containerd package name
+
+Default value: `$k8s::containerd_package`
 
 ##### <a name="-k8s--install--container_runtime--runc_version"></a>`runc_version`
 
 Data type: `String[1]`
 
-the runc version
+The runc version
 
 Default value: `$k8s::runc_version`
+
+##### <a name="-k8s--install--container_runtime--package_ensure"></a>`package_ensure`
+
+Data type: `String[1]`
+
+The ensure value to set on the cri package
+
+Default value: `installed`
 
 ### <a name="k8s--install--crictl"></a>`k8s::install::crictl`
 
@@ -1258,10 +1249,17 @@ Handles repositories for the container runtime
 
 The following parameters are available in the `k8s::repo` class:
 
-* [`container_manager`](#-k8s--repo--container_manager)
-* [`crio_version`](#-k8s--repo--crio_version)
 * [`manage_container_manager`](#-k8s--repo--manage_container_manager)
+* [`container_manager`](#-k8s--repo--container_manager)
 * [`major_version`](#-k8s--repo--major_version)
+
+##### <a name="-k8s--repo--manage_container_manager"></a>`manage_container_manager`
+
+Data type: `Boolean`
+
+Whether to add the CRI-o repository or not
+
+Default value: `$k8s::manage_container_manager`
 
 ##### <a name="-k8s--repo--container_manager"></a>`container_manager`
 
@@ -1271,23 +1269,11 @@ The name of the container manager
 
 Default value: `$k8s::container_manager`
 
-##### <a name="-k8s--repo--crio_version"></a>`crio_version`
-
-version o cri-o
-
-##### <a name="-k8s--repo--manage_container_manager"></a>`manage_container_manager`
-
-Data type: `Boolean`
-
-whether to add cri-o repository or not
-
-Default value: `$k8s::manage_container_manager`
-
 ##### <a name="-k8s--repo--major_version"></a>`major_version`
 
 Data type: `String[1]`
 
-
+The major version of Kubernetes to deploy repos for
 
 Default value: `$k8s::version.split('\.')[0, 2].join('.')`
 

--- a/manifests/install/cni_plugins.pp
+++ b/manifests/install/cni_plugins.pp
@@ -1,11 +1,10 @@
-# Class: k8s::install::cni_plugins
+# @summary Manages the installation of CNI plugins
 #
-# @summary manages the installation of the cni plugins
-#
-# @param ensure set ensure for installation or deinstallation
-# @param method installation method
-# @param version sets the version to use
-# @param download_url_template template string for the cni_plugins download url
+# @param ensure Set ensure for installation or deinstallation
+# @param method The installation method to use
+# @param version The version of CNI plugins to install - if applicable
+# @param download_url_template Template string for the cni_plugins download url
+# @param package_name Package name for the CNI plugins, will use OS default if omitted
 #
 class k8s::install::cni_plugins (
   K8s::Ensure $ensure               = $k8s::ensure,

--- a/manifests/install/container_runtime.pp
+++ b/manifests/install/container_runtime.pp
@@ -52,13 +52,13 @@ class k8s::install::container_runtime (
         require => Package['k8s container manager'],
       }
 
-      file { [ '/etc/crio', '/etc/crio/crio.conf.d']:
+      file { ['/etc/crio', '/etc/crio/crio.conf.d']:
         ensure => directory;
       }
       file { 'K8s crio cgroup manager':
-        path     => '/etc/crio/crio.conf.d/10-systemd.conf',
-        content  => "[crio.runtime]\ncgroup_manager = \"systemd\"",
-        # TODO
+        path    => '/etc/crio/crio.conf.d/10-systemd.conf',
+        content => "[crio.runtime]\ncgroup_manager = \"systemd\"",
+        # TODO - Necessary/wanted to force it?
         # notify => Service[crio],
       }
     }

--- a/manifests/install/container_runtime.pp
+++ b/manifests/install/container_runtime.pp
@@ -1,21 +1,17 @@
-# Class: k8s::install::container_runtime
+# @summary Manages the installation of a container runtime / CRI
 #
-# @summary manages the installation of cri
-#
-# @param container_manager set the cri to use
-# @param containerd_package the containerd package anme
-# @param crio_package cri-o the package name
-# @param k8s_version the k8s version
-# @param manage_repo whether to manage the repo or not
-# @param package_ensure the ensure value to set on the cri package
-# @param runc_version the runc version
+# @param manage_repo Whether to manage the repo or not
+# @param container_manager The CRI implementation to install
+# @param crio_package The CRI-o package name
+# @param containerd_package The containerd package name
+# @param runc_version The runc version
+# @param package_ensure The ensure value to set on the cri package
 #
 class k8s::install::container_runtime (
   Boolean $manage_repo                       = $k8s::manage_repo,
   K8s::Container_runtimes $container_manager = $k8s::container_manager,
   Optional[String[1]] $crio_package          = $k8s::crio_package,
   Optional[String[1]] $containerd_package    = $k8s::containerd_package,
-  String[1] $k8s_version                     = $k8s::version,
   String[1] $runc_version                    = $k8s::runc_version,
   String[1] $package_ensure                  = installed,
 ) {

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,8 +1,8 @@
 # @summary Handles repositories for the container runtime
 #
+# @param manage_container_manager Whether to add the CRI-o repository or not
 # @param container_manager The name of the container manager
-# @param crio_version version o cri-o
-# @param manage_container_manager whether to add cri-o repository or not
+# @param major_version The major version of Kubernetes to deploy repos for
 #
 class k8s::repo (
   Boolean $manage_container_manager          = $k8s::manage_container_manager,

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -14,6 +14,9 @@ class k8s::repo (
       $core_url = "https://pkgs.k8s.io/core:/stable:/v${major_version}/deb"
       $crio_url = "https://pkgs.k8s.io/addons:/cri-o:/stable:/v${major_version}/deb"
 
+      apt::source { 'libcontainers:stable':
+        ensure => absent,
+      }
       apt::source { 'k8s-core':
         location => $core_url,
         repos    => '/',
@@ -25,6 +28,9 @@ class k8s::repo (
       }
 
       if $manage_container_manager and $container_manager == 'crio' {
+        apt::source { 'libcontainers:stable:cri-o':
+          ensure => absent,
+        }
         apt::source { 'k8s-crio':
           location => $crio_url,
           repos    => '/',
@@ -46,6 +52,9 @@ class k8s::repo (
       $core_url = "https://pkgs.k8s.io/core:/stable:/v${major_version}/rpm"
       $crio_url = "https://pkgs.k8s.io/addons:/cri-o:/stable:/v${major_version}/rpm"
 
+      yumrepo { 'libcontainers:stable':
+        ensure => absent,
+      }
       yumrepo { 'k8s-core':
         descr    => 'Stable releases of Kubernetes',
         baseurl  => $core_url,
@@ -56,6 +65,9 @@ class k8s::repo (
       if $manage_container_manager {
         case $container_manager {
           'crio': {
+            yumrepo { 'libcontainers:stable:cri-o':
+              ensure => absent,
+            }
             yumrepo { 'k8s-crio':
               descr    => 'Stable releases of CRI-o',
               baseurl  => $crio_url,

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -7,68 +7,56 @@
 class k8s::repo (
   Boolean $manage_container_manager          = $k8s::manage_container_manager,
   K8s::Container_runtimes $container_manager = $k8s::container_manager,
-  String[1] $crio_version                    = $k8s::version.split('\.')[0, 2].join('.'),
+  String[1] $major_version                   = $k8s::version.split('\.')[0, 2].join('.'),
 ) {
   case fact('os.family') {
     'Debian': {
-      case fact('os.name') {
-        'Debian': {
-          if versioncmp($crio_version, '1.19') >= 0 {
-            $release_name = "Debian_${fact('os.release.major')}"
-          } else {
-            $release_name = 'Debian_Testing'
-          }
-        }
-        'Ubuntu': {
-          $release_name = "xUbuntu_${fact('os.release.full')}"
-        }
-        'Raspbian': {
-          $release_name = "Raspbian_${fact('os.release.full')}"
-        }
-        default: {}
-      }
+      $core_url = "https://pkgs.k8s.io/core:/stable:/v${major_version}/deb"
+      $crio_url = "https://pkgs.k8s.io/addons:/cri-o:/stable:/v${major_version}/deb"
 
-      $libcontainers_url = "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/${release_name}"
-      $crio_url          = "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/${crio_version}/${release_name}"
-
-      apt::source { 'libcontainers:stable':
-        location => $libcontainers_url,
+      apt::source { 'k8s-core':
+        location => $core_url,
         repos    => '/',
         release  => '',
         key      => {
-          id     => '2472D6D0D2F66AF87ABA8DA34D64390375060AA4',
-          source => "${libcontainers_url}/Release.key",
+          name   => 'k8s-core-apt-keyring.asc',
+          source => "${core_url}/Release.key",
         },
       }
 
       if $manage_container_manager and $container_manager == 'crio' {
-        apt::source { 'libcontainers:stable:cri-o':
+        apt::source { 'k8s-crio':
           location => $crio_url,
           repos    => '/',
           release  => '',
           key      => {
-            id     => '2472D6D0D2F66AF87ABA8DA34D64390375060AA4',
+            name   => 'k8s-crio-apt-keyring.asc',
             source => "${crio_url}/Release.key",
           },
+        }
+        ~> exec { 'Fix conmon upgrade collision':
+          command     => 'dpkg --no-triggers --force depends -r conmon',
+          onlyif      => 'dpkg -S /usr/libexec/crio/conmon | grep "conmon:"',
+          refreshonly => true,
+          path        => fact('path'),
         }
       }
     }
     'RedHat': {
-      $release_name = if versioncmp(fact('os.release.major'), '7') == 1 { "CentOS_${fact('os.release.major')}_Stream" } else { "CentOS_${fact('os.release.major')}" }
-      $libcontainers_url = "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/${release_name}/"
-      $crio_url          = "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/${crio_version}/${release_name}/"
+      $core_url = "https://pkgs.k8s.io/core:/stable:/v${major_version}/rpm"
+      $crio_url = "https://pkgs.k8s.io/addons:/cri-o:/stable:/v${major_version}/rpm"
 
-      yumrepo { 'libcontainers:stable':
-        descr    => 'Stable releases of libcontainers',
-        baseurl  => $libcontainers_url,
+      yumrepo { 'k8s-core':
+        descr    => 'Stable releases of Kubernetes',
+        baseurl  => $core_url,
         gpgcheck => 1,
-        gpgkey   => "${libcontainers_url}repodata/repomd.xml.key",
+        gpgkey   => "${core_url}repodata/repomd.xml.key",
       }
 
       if $manage_container_manager {
         case $container_manager {
           'crio': {
-            yumrepo { 'libcontainers:stable:cri-o':
+            yumrepo { 'k8s-crio':
               descr    => 'Stable releases of CRI-o',
               baseurl  => $crio_url,
               gpgcheck => 1,


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Replaces the old kubic repositories with the isv:kubernetes `pkg.k8s.io` repositories instead, to keep support for non-EoL Kubernetes.
Also includes the necessary mid-step to support migrating a Debian install over to the new packages, as there are some differences in them.

#### This Pull Request (PR) fixes the following issues
Supersedes #94

Fixes #77 
Might improve #47 according to superseded PR - but not personally tested