### PR TITLE
Correctly handle default name/discovery tag for etcd

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1292,11 +1292,11 @@ Default value: `"${cert_path}/client-ca.key"`
 
 ##### <a name="-k8s--server--etcd--cluster_name"></a>`cluster_name`
 
-Data type: `Optional[String[1]]`
+Data type: `String[1]`
 
 name of the etcd cluster for searching its nodes in the puppetdb, will use k8s::etcd_cluster_name unless otherwise specified
 
-Default value: `undef`
+Default value: `'default'`
 
 ##### <a name="-k8s--server--etcd--ensure"></a>`ensure`
 
@@ -1380,7 +1380,7 @@ Default value: `"${cert_path}/peer-ca.key"`
 
 ##### <a name="-k8s--server--etcd--puppetdb_discovery_tag"></a>`puppetdb_discovery_tag`
 
-Data type: `Optional[String[1]]`
+Data type: `String[1]`
 
 enable puppetdb resource searching
 

--- a/manifests/server/apiserver.pp
+++ b/manifests/server/apiserver.pp
@@ -39,7 +39,7 @@ class k8s::server::apiserver (
   Optional[Array[Stdlib::HTTPUrl]] $etcd_servers = $k8s::server::etcd_servers,
   Boolean $discover_etcd_servers                 = $k8s::puppetdb_discovery,
   Boolean $manage_firewall                       = $k8s::server::manage_firewall,
-  String $puppetdb_discovery_tag                 = $k8s::server::puppetdb_discovery_tag,
+  String[1] $puppetdb_discovery_tag              = $k8s::server::puppetdb_discovery_tag,
   Stdlib::Unixpath $cert_path              = $k8s::server::tls::cert_path,
   Stdlib::Unixpath $ca_cert                = $k8s::server::tls::ca_cert,
   Stdlib::Unixpath $aggregator_ca_cert     = $k8s::server::tls::aggregator_ca_cert,

--- a/manifests/server/etcd.pp
+++ b/manifests/server/etcd.pp
@@ -27,8 +27,8 @@ class k8s::server::etcd (
   Boolean $manage_setup                       = true,
   Boolean $manage_firewall                    = false,
   Boolean $manage_members                     = false,
-  Optional[String[1]] $cluster_name           = undef,
-  Optional[String[1]] $puppetdb_discovery_tag = $cluster_name,
+  String[1] $cluster_name                     = 'default',
+  String[1] $puppetdb_discovery_tag           = $cluster_name,
 
   Boolean $self_signed_tls = false,
   Boolean $manage_certs    = true,
@@ -119,9 +119,6 @@ class k8s::server::etcd (
   }
 
   if $ensure == 'present' and $manage_members {
-    $_cluster_name = pick($cluster_name, $k8s::etcd_cluster_name, 'default')
-    $_puppetdb_discovery_tag = pick($puppetdb_discovery_tag, $cluster_name, $k8s::puppetdb_discovery_tag, 'default')
-
     # Needs the PuppetDB terminus installed
     $pql_query = [
       'resources[certname,parameters] {',
@@ -131,8 +128,8 @@ class k8s::server::etcd (
       '    resources {',
       '      type = \'Class\' and',
       '      title = \'K8s::Server::Etcd\' and',
-      "      parameters.cluster_name = '${_cluster_name}' and",
-      "      parameters.puppetdb_discovery_tag = '${_puppetdb_discovery_tag}' and",
+      "      parameters.cluster_name = '${cluster_name}' and",
+      "      parameters.puppetdb_discovery_tag = '${puppetdb_discovery_tag}' and",
       "      certname != '${trusted[certname]}'",
       '    }',
       '  }',


### PR DESCRIPTION
Actually missed the (really quite common) use-case of not having any cluster separation for ETCD on #66, so a quick fix to handle that correctly.