### PR TITLE
Support configuration of waiting times

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1734,7 +1734,7 @@ Data type: `Integer`
 
 Number of retries
 
-Default value: `2`
+Default value: `15`
 
 ##### <a name="-k8s--server--wait_online--try_sleep"></a>`try_sleep`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1720,6 +1720,38 @@ Default value: `$k8s::etcd_version`
 
 Creates a dummy exec to allow deferring applies until the Kubernetes API server has started
 
+#### Parameters
+
+The following parameters are available in the `k8s::server::wait_online` class:
+
+* [`tries`](#-k8s--server--wait_online--tries)
+* [`try_sleep`](#-k8s--server--wait_online--try_sleep)
+* [`timeout`](#-k8s--server--wait_online--timeout)
+
+##### <a name="-k8s--server--wait_online--tries"></a>`tries`
+
+Data type: `Integer`
+
+Number of retries
+
+Default value: `2`
+
+##### <a name="-k8s--server--wait_online--try_sleep"></a>`try_sleep`
+
+Data type: `Integer`
+
+Sleep time in seconds
+
+Default value: `2`
+
+##### <a name="-k8s--server--wait_online--timeout"></a>`timeout`
+
+Data type: `Integer`
+
+Execution timeout in seconds (0 to disable)
+
+Default value: `5`
+
 ## Defined types
 
 ### <a name="k8s--binary"></a>`k8s::binary`

--- a/manifests/server/wait_online.pp
+++ b/manifests/server/wait_online.pp
@@ -4,11 +4,11 @@
 # @param try_sleep Sleep time in seconds
 # @param timeout Execution timeout in seconds (0 to disable)
 class k8s::server::wait_online (
-  Integer $tries = 2,
+  Integer $tries = 15,
   Integer $timeout = 5,
   Integer $try_sleep = 2,
 ) {
-  # Wait up to 30 seconds for kube-apiserver to start
+  # Wait up to $tries * ( $timeout + $try_sleep) seconds for kube-apiserver to start
   exec { 'k8s apiserver wait online':
     command     => 'kubectl --kubeconfig /root/.kube/config version',
     path        => $facts['path'],

--- a/manifests/server/wait_online.pp
+++ b/manifests/server/wait_online.pp
@@ -1,13 +1,21 @@
 # @summary Creates a dummy exec to allow deferring applies until the Kubernetes API server has started
 #
-class k8s::server::wait_online {
+# @param tries Number of retries
+# @param try_sleep Sleep time in seconds
+# @param timeout Execution timeout in seconds (0 to disable)
+class k8s::server::wait_online (
+  Integer $tries = 2,
+  Integer $timeout = 5,
+  Integer $try_sleep = 2,
+) {
   # Wait up to 30 seconds for kube-apiserver to start
   exec { 'k8s apiserver wait online':
     command     => 'kubectl --kubeconfig /root/.kube/config version',
     path        => $facts['path'],
     refreshonly => true,
-    tries       => 15,
-    try_sleep   => 2,
+    tries       => $tries,
+    try_sleep   => $try_sleep,
+    timeout     => $timeout,
   }
 
   # Require possibly managed components before checking online state


### PR DESCRIPTION
Default execution timeout is 300 seconds, with 15 retries it could stall puppet for 45 minutes if api server is not running.
