### PR TITLE
Retain custom CNI plugins over upgrades

### DIFF
--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -33,6 +33,9 @@ class k8s::common {
     '/opt/k8s': ;
     '/opt/k8s/bin': ;
   }
+  ['/etc/facter','/etc/facter/facts.d'].each |$path| {
+    ensure_resource('file', $path, { ensure => directory })
+  }
 
   file { '/var/run/kubernetes':
     ensure => directory,

--- a/spec/classes/install/cni_plugins_spec.rb
+++ b/spec/classes/install/cni_plugins_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'k8s::install::cni_plugins' do
+  let(:pre_condition) do
+    <<~PUPPET
+      include k8s
+    PUPPET
+  end
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+      it { is_expected.to contain_file('/opt/cni') }
+
+      context 'when method is tarball' do
+        let(:params) do
+          {
+            method: 'tarball',
+            version: 'v1.0.0'
+          }
+        end
+
+        it { is_expected.to contain_archive('cni-plugins').with_extract_path('/opt/k8s/cni-v1.0.0') }
+
+        context 'without storage fact' do
+          it { is_expected.not_to contain_exec('Retain custom CNI binaries') }
+        end
+
+        context 'with storage fact' do
+          let(:facts) { os_facts.merge(cni_plugins_version: 'v0.0.0') }
+
+          it { is_expected.to contain_exec('Retain custom CNI binaries') }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### Pull Request (PR) description

Keeps custom CNI binaries around between upgrades of the main CNI plugins, to remove the need to redeploy any custom binaries that have been installed during the lifetime of the node/cluster.

#### This Pull Request (PR) fixes the following issues

Fixes #107

