### PR TITLE
Make etcd initial_cluster unique list

### DIFF
--- a/manifests/server/etcd/setup.pp
+++ b/manifests/server/etcd/setup.pp
@@ -182,9 +182,9 @@ class k8s::server::etcd::setup (
     $_peer_client_cert_auth = $peer_client_cert_auth
   }
 
-  $_initial_cluster = [
-    "${etcd_name}=${initial_advertise_peer_urls[0]}"
-  ] + $initial_cluster
+  $_initial_cluster = ([
+      "${etcd_name}=${initial_advertise_peer_urls[0]}"
+  ] + $initial_cluster).unique
 
   file {
     default:


### PR DESCRIPTION
#### Pull Request (PR) description
Ensure that the etcd parameter specifying the list of etcd servers in a cluster is unique. This helps when `k8s::server::etcd::setup::initial_cluster` is not empty - allows to set the value globally for the whole cluster, not for each node separately without itself.

                   