### PR TITLE
Ensure proper ordering for scheduler and controller manager configs

### DIFF
--- a/manifests/server/controller_manager.pp
+++ b/manifests/server/controller_manager.pp
@@ -89,6 +89,7 @@ class k8s::server::controller_manager (
       ca_cert         => $ca_cert,
       client_cert     => $cert,
       client_key      => $key,
+      require         => File['/srv/kubernetes'],
     }
 
     file { "${k8s::sysconfig_path}/kube-controller-manager":

--- a/manifests/server/scheduler.pp
+++ b/manifests/server/scheduler.pp
@@ -68,6 +68,7 @@ class k8s::server::scheduler (
       ca_cert         => $ca_cert,
       client_cert     => $cert,
       client_key      => $key,
+      require         => File['/srv/kubernetes'],
     }
     file { "${k8s::sysconfig_path}/kube-scheduler":
       content => epp('k8s/sysconfig.epp', {


### PR DESCRIPTION
Avoid errors like:
```
(/Stage[main]/K8s::Server::Controller_manager/Kubeconfig[/srv/kubernetes/kube-controller-manager.kubeconf]) Could not evaluate: No such file or director>
(/Stage[main]/K8s::Server::Scheduler/Kubeconfig[/srv/kubernetes/kube-scheduler.kubeconf]) Could not evaluate: No such file or directory @ rb_sysopen - />
```