### PR TITLE
Fix crio package repository, allow data adjustment

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -971,6 +971,8 @@ The following parameters are available in the `k8s::repo` class:
 * [`manage_container_manager`](#-k8s--repo--manage_container_manager)
 * [`container_manager`](#-k8s--repo--container_manager)
 * [`major_version`](#-k8s--repo--major_version)
+* [`core_package_base`](#-k8s--repo--core_package_base)
+* [`crio_package_base`](#-k8s--repo--crio_package_base)
 
 ##### <a name="-k8s--repo--manage_container_manager"></a>`manage_container_manager`
 
@@ -995,6 +997,22 @@ Data type: `String[1]`
 The major version of Kubernetes to deploy repos for
 
 Default value: `$k8s::version.split('\.')[0, 2].join('.')`
+
+##### <a name="-k8s--repo--core_package_base"></a>`core_package_base`
+
+Data type: `String[1]`
+
+The url base of the k8s core packages
+
+Default value: `'https://pkgs.k8s.io/core:/stable'`
+
+##### <a name="-k8s--repo--crio_package_base"></a>`crio_package_base`
+
+Data type: `String[1]`
+
+The url base of the cri-o packages
+
+Default value: `'https://download.opensuse.org/repositories/isv:/cri-o:/stable'`
 
 ### <a name="k8s--server"></a>`k8s::server`
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -3,16 +3,20 @@
 # @param manage_container_manager Whether to add the CRI-o repository or not
 # @param container_manager The name of the container manager
 # @param major_version The major version of Kubernetes to deploy repos for
+# @param core_package_base The url base of the k8s core packages
+# @param crio_package_base The url base of the cri-o packages
 #
 class k8s::repo (
   Boolean $manage_container_manager          = $k8s::manage_container_manager,
   K8s::Container_runtimes $container_manager = $k8s::container_manager,
   String[1] $major_version                   = $k8s::version.split('\.')[0, 2].join('.'),
+  String[1] $core_package_base               = 'https://pkgs.k8s.io/core:/stable',
+  String[1] $crio_package_base               = 'https://download.opensuse.org/repositories/isv:/cri-o:/stable',
 ) {
   case fact('os.family') {
     'Debian': {
-      $core_url = "https://pkgs.k8s.io/core:/stable:/v${major_version}/deb"
-      $crio_url = "https://pkgs.k8s.io/addons:/cri-o:/stable:/v${major_version}/deb"
+      $core_url = "${core_package_base}:/v${major_version}/deb"
+      $crio_url = "${crio_package_base}:/v${major_version}/deb"
 
       apt::source { 'libcontainers:stable':
         ensure => absent,
@@ -49,8 +53,8 @@ class k8s::repo (
       }
     }
     'RedHat': {
-      $core_url = "https://pkgs.k8s.io/core:/stable:/v${major_version}/rpm"
-      $crio_url = "https://pkgs.k8s.io/addons:/cri-o:/stable:/v${major_version}/rpm"
+      $core_url = "${core_package_base}:/v${major_version}/rpm"
+      $crio_url = "${crio_package_base}:/v${major_version}/rpm"
 
       yumrepo { 'libcontainers:stable':
         ensure => absent,
@@ -59,7 +63,7 @@ class k8s::repo (
         descr    => 'Stable releases of Kubernetes',
         baseurl  => $core_url,
         gpgcheck => 1,
-        gpgkey   => "${core_url}repodata/repomd.xml.key",
+        gpgkey   => "${core_url}/repodata/repomd.xml.key",
       }
 
       if $manage_container_manager {
@@ -72,7 +76,7 @@ class k8s::repo (
               descr    => 'Stable releases of CRI-o',
               baseurl  => $crio_url,
               gpgcheck => 1,
-              gpgkey   => "${crio_url}repodata/repomd.xml.key",
+              gpgkey   => "${crio_url}/repodata/repomd.xml.key",
             }
           }
           'containerd': {


### PR DESCRIPTION
#### Pull Request (PR) description

The current package repository for CRIO is incorrect according to https://github.com/cri-o/packaging. The current value does not work on RedHat nodes:

```
Status code: 403 for https://prod-cdn.packages.k8s.io/repositories/isv:/kubernetes:/core:/stable:/v1.32/rpmrepodata/repomd.xml.key (IP: 18.244.214.76)
```

## Additional benefits

By moving the package base to a parameter, this would allow someone to 

* fix it should the group change it again
* choose to run another variant such as an unstable build