### PR TITLE
Breakfix: flannel forbidden to query pod

### DIFF
--- a/manifests/server/resources/flannel.pp
+++ b/manifests/server/resources/flannel.pp
@@ -155,7 +155,7 @@ class k8s::server::resources::flannel (
           {
             apiGroups => [''],
             resources => ['pods','nodes','namespaces'],
-            verbs     => ['list','watch'],
+            verbs     => ['get','list','watch'],
           },
           {
             apiGroups => [''],


### PR DESCRIPTION
#### Pull Request (PR) description

Installation with flannel enabled (all default settings) has been broken since #116 
It will fail to start the CNI with this message:

```
Failed to create SubnetManager: error retrieving pod spec for 'kube-system/flannel-*****': pods "flannel-*****" is forbidden: User "system:serviceaccount:kube-system:flannel" cannot get resource "pods" in API group "" in the namespace "kube-system"
```

#### This Pull Request (PR) fixes the following issues

Allows `get` operation removed in #116 which flannel requires to start