### PR TITLE
Fix incompatible key usage errors for etcd v3.5

### DIFF
--- a/manifests/server/etcd.pp
+++ b/manifests/server/etcd.pp
@@ -98,7 +98,7 @@ class k8s::server::etcd (
         distinguished_name => {
           commonName => fact('networking.fqdn'),
         },
-        extended_key_usage => ['serverAuth'];
+        extended_key_usage => ['serverAuth', 'clientAuth'];
 
       'etcd-peer':
         ca_key             => $peer_ca_key,


### PR DESCRIPTION
#### Pull Request (PR) description

Add `clientAuth` to the list of etcd extended key usages

#### This Pull Request (PR) fixes the following issues

```
Jun 16 09:22:28 example etcd[10992]: {"level":"warn","ts":"2025-06-16T09:22:28.579816Z","caller":"embed/config_logging.go:169","msg":"rejected connection","remote-addr":"[::1]:35480","server-name":"","error":"tls: failed to verify certificate: x509: certificate specifies an incompatible key usage"}
Jun 16 09:22:28 example etcd[10992]: 2025/06/16 09:22:28 WARNING: [core] [Channel #3 SubChannel #4] grpc: addrConn.createTransport failed to connect to {Addr: "[::]:2379", ServerName: "[::]:2379", }. Err: connection error: desc = "error reading server preface: remote error: tls: bad certificate"
```

This can be confirmed from the generated cert:

```shell
$ openssl x509 -in /var/lib/etcd/certs/etcd-server.pem -noout -text |grep -A2 'Extended Key Usage'
            X509v3 Extended Key Usage:
                TLS Web Server Authentication
            X509v3 Subject Alternative Name:
```