### PR TITLE
Fix a convergence issue

### DIFF
--- a/manifests/server/resources/kube_proxy.pp
+++ b/manifests/server/resources/kube_proxy.pp
@@ -209,7 +209,7 @@ class k8s::server::resources::kube_proxy (
                     {
                       mountPath => '/run/xtables.lock',
                       name      => 'iptables-lock',
-                      readOnly  => false,
+                      readOnly  => undef,
                     },
                     {
                       mountPath => '/lib/modules',

--- a/spec/fixtures/files/resources/kube-proxy.yaml
+++ b/spec/fixtures/files/resources/kube-proxy.yaml
@@ -41,7 +41,7 @@ spec:
           readOnly: true
         - mountPath: "/run/xtables.lock"
           name: iptables-lock
-          readOnly: false
+          readOnly: null
         - mountPath: "/lib/modules"
           name: lib-modules
           readOnly: true


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

On modern Kubernetes, `readOnly: false` is stripped from the generated YAML, making Puppet attempt to patch it back in on every run.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
