### PR TITLE
Add parameter to defer management of /etc/facter/facts.d

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -114,6 +114,7 @@ The following parameters are available in the `k8s` class:
 * [`incluster_control_plane_url`](#-k8s--incluster_control_plane_url)
 * [`manage_container_manager`](#-k8s--manage_container_manager)
 * [`manage_etcd`](#-k8s--manage_etcd)
+* [`manage_facter`](#-k8s--manage_facter)
 * [`manage_firewall`](#-k8s--manage_firewall)
 * [`manage_image`](#-k8s--manage_image)
 * [`manage_kernel_modules`](#-k8s--manage_kernel_modules)
@@ -311,6 +312,14 @@ Default value: `true`
 Data type: `Boolean`
 
 whether to manage etcd
+
+Default value: `true`
+
+##### <a name="-k8s--manage_facter"></a>`manage_facter`
+
+Data type: `Boolean`
+
+whether to manage facter facts.d folders
 
 Default value: `true`
 

--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -33,8 +33,10 @@ class k8s::common {
     '/opt/k8s': ;
     '/opt/k8s/bin': ;
   }
-  ['/etc/facter','/etc/facter/facts.d'].each |$path| {
-    ensure_resource('file', $path, { ensure => directory })
+  if $k8s::manage_facter {
+    ['/etc/facter','/etc/facter/facts.d'].each |$path| {
+      ensure_resource('file', $path, { ensure => directory })
+    }
   }
 
   file { '/var/run/kubernetes':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,7 @@
 # @param incluster_control_plane_url URL for the control plane from within the cluster
 # @param manage_container_manager whether to manage the container manager
 # @param manage_etcd whether to manage etcd
+# @param manage_facter whether to manage facter facts.d folders
 # @param manage_firewall whether to manage the firewall
 # @param manage_image whether to manage the image
 # @param manage_kernel_modules A flag to manage required Kernel modules.
@@ -64,6 +65,7 @@ class k8s (
   String[1] $runc_version                    = 'installed',
 
   Boolean $manage_etcd                 = true,
+  Boolean $manage_facter               = true,
   Boolean $manage_firewall             = false,
   Boolean $manage_kernel_modules       = true,
   Boolean $manage_sysctl_settings      = true,


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This improves support for cases where `/etc/facter` - and `facts.d` - is managed with non-standard config in the same environment - FreeBSD in our case

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
