### PR TITLE
Add manifest for installing FluxCD

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,6 +4,7 @@ fixtures:
     archive: https://github.com/voxpupuli/puppet-archive
     augeasproviders_core: https://github.com/voxpupuli/puppet-augeasproviders_core
     augeasproviders_sysctl: https://github.com/voxpupuli/puppet-augeasproviders_sysctl
+    extlib: https://github.com/voxpupuli/puppet-extlib
     kmod: https://github.com/voxpupuli/puppet-kmod
     stdlib: https://github.com/puppetlabs/puppetlabs-stdlib
     systemd: https://github.com/voxpupuli/puppet-systemd

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -12,6 +12,7 @@
 * [`k8s::install::cni_plugins`](#k8s--install--cni_plugins): Manages the installation of CNI plugins
 * [`k8s::install::container_runtime`](#k8s--install--container_runtime): Manages the installation of a container runtime / CRI
 * [`k8s::install::crictl`](#k8s--install--crictl): installs the crictl debugging tool
+* [`k8s::install::fluxcd`](#k8s--install--fluxcd): Installs the FluxCD CLI, and optionally also installs Flux into on the cluster
 * [`k8s::install::kubeadm`](#k8s--install--kubeadm): Installs the kubeadm binary
 * [`k8s::install::kubectl`](#k8s--install--kubectl): Installs the kubectl binary
 * [`k8s::node`](#k8s--node): Installs a Kubernetes node
@@ -689,6 +690,90 @@ Data type: `Stdlib::HTTPUrl`
 template string for the URL to download tar.gz from
 
 Default value: `'https://github.com/kubernetes-sigs/cri-tools/releases/download/%{version}/crictl-%{version}-linux-%{arch}.tar.gz'`
+
+### <a name="k8s--install--fluxcd"></a>`k8s::install::fluxcd`
+
+Installs the FluxCD CLI, and optionally also installs Flux into on the cluster
+
+#### Examples
+
+##### Install - and automatically update - latest version of Flux
+
+```puppet
+class { 'k8s::install::fluxcd':
+  ensure => latest,
+}
+```
+
+##### Install flux with different components
+
+```puppet
+class { 'k8s::install::fluxcd':
+  install_options => {
+    components       => ['source-controller', 'kustomize-controller']
+    components_extra => ['source-watcher', 'image-reflector-controller']
+  }
+}
+```
+
+#### Parameters
+
+The following parameters are available in the `k8s::install::fluxcd` class:
+
+* [`ensure`](#-k8s--install--fluxcd--ensure)
+* [`install`](#-k8s--install--fluxcd--install)
+* [`install_options`](#-k8s--install--fluxcd--install_options)
+* [`upgrade`](#-k8s--install--fluxcd--upgrade)
+* [`install_dir`](#-k8s--install--fluxcd--install_dir)
+* [`kubeconfig`](#-k8s--install--fluxcd--kubeconfig)
+
+##### <a name="-k8s--install--fluxcd--ensure"></a>`ensure`
+
+Data type: `Variant[Enum['absent', 'present', 'latest'], String[1]]`
+
+The FluxCD version to install, or present/latest for the latest at the time
+
+Default value: `'present'`
+
+##### <a name="-k8s--install--fluxcd--install"></a>`install`
+
+Data type: `Optional[Boolean]`
+
+If FluxCD should be installed into the local cluster, will default to true on k8s::server nodes
+
+Default value: `undef`
+
+##### <a name="-k8s--install--fluxcd--install_options"></a>`install_options`
+
+Data type: `Hash[String, Data]`
+
+Additional options to provide to the `flux install` invocation
+
+Default value: `{}`
+
+##### <a name="-k8s--install--fluxcd--upgrade"></a>`upgrade`
+
+Data type: `Boolean`
+
+Upgrade FluxCD on the local cluster if the version changes
+
+Default value: `true`
+
+##### <a name="-k8s--install--fluxcd--install_dir"></a>`install_dir`
+
+Data type: `Stdlib::Unixpath`
+
+Where to install the FluxCD binary
+
+Default value: `'/usr/local/bin'`
+
+##### <a name="-k8s--install--fluxcd--kubeconfig"></a>`kubeconfig`
+
+Data type: `Stdlib::Unixpath`
+
+The kubeconfig file to use when installing/upgrading FluxCD
+
+Default value: `'/root/.kube/config'`
 
 ### <a name="k8s--install--kubeadm"></a>`k8s::install::kubeadm`
 

--- a/manifests/install/fluxcd.pp
+++ b/manifests/install/fluxcd.pp
@@ -1,0 +1,129 @@
+# @summary Installs the FluxCD CLI, and optionally also installs Flux into on the cluster
+#
+# @example Install - and automatically update - latest version of Flux
+#   class { 'k8s::install::fluxcd':
+#     ensure => latest,
+#   }
+#
+# @example Install flux with different components
+#   class { 'k8s::install::fluxcd':
+#     install_options => {
+#       components       => ['source-controller', 'kustomize-controller']
+#       components_extra => ['source-watcher', 'image-reflector-controller']
+#     }
+#   }
+#
+# @param ensure The FluxCD version to install, or present/latest for the latest at the time
+# @param install If FluxCD should be installed into the local cluster, will default to true on k8s::server nodes
+# @param install_options Additional options to provide to the `flux install` invocation
+# @param upgrade Upgrade FluxCD on the local cluster if the version changes
+# @param install_dir Where to install the FluxCD binary
+# @param kubeconfig The kubeconfig file to use when installing/upgrading FluxCD
+class k8s::install::fluxcd (
+  Variant[Enum['absent', 'present', 'latest'], String[1]] $ensure = 'present',
+
+  Optional[Boolean] $install = undef,
+  Hash[String, Data] $install_options = {},
+  Boolean $upgrade = true,
+
+  Stdlib::Unixpath $install_dir = '/usr/local/bin',
+  Stdlib::Unixpath $kubeconfig = '/root/.kube/config',
+) {
+  if $ensure == 'absent' {
+    file { '/usr/local/bin/flux':
+      ensure => absent,
+    }
+    tidy { 'Old FluxCD installs':
+      path    => $install_dir,
+      recurse => 1,
+      matches => 'flux-*',
+    }
+    return()
+  }
+
+  if $ensure == 'latest' or $ensure == 'present' {
+    $latest = extlib::version_latest_github('fluxcd/flux2')
+    $_version = $latest.regsubst('^v?(.+)$', '\1', 'I')
+  } else {
+    $_version = $ensure
+    $latest = "v${_version}"
+  }
+
+  if $_version !~ Pattern[/^\d+(\.\d+){2}$/] {
+    fail("Version '${_version}' is not a valid FluxCD version")
+  }
+
+  if $ensure == 'present' {
+    $path = "${install_dir}/flux"
+    $transform_command = ''
+  } else {
+    # Use version-specific flux binary, so that the archive resource detects version changes
+    $path = "${install_dir}/flux-${_version}"
+    $transform_command = "--transform='s/flux/flux-${_version}/'"
+
+    Archive['FluxCD CLI']
+    -> file { "${install_dir}/flux":
+      ensure  => link,
+      target  => $path,
+      replace => true,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0755',
+    }
+    ~> tidy { 'Old FluxCD installs':
+      path    => $install_dir,
+      recurse => 1,
+      matches => 'flux-*',
+    }
+  }
+
+  archive { 'FluxCD CLI':
+    ensure          => present,
+    path            => '/tmp/fluxcd.tar.gz',
+    source          => "https://github.com/fluxcd/flux2/releases/download/${latest}/flux_${_version}_linux_amd64.tar.gz",
+    extract         => true,
+    extract_command => "tar -C /usr/local/bin -xf %s ${transform_command} flux",
+    extract_path    => $install_dir,
+    cleanup         => true,
+    creates         => $path,
+  }
+  -> file { $path:
+    ensure  => file,
+    replace => false,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0755',
+  }
+
+  if pick($install, defined('k8s::server')) {
+    $install_flags = $install_options.map |$flag, $value| {
+      if $value =~ Array {
+        $_value = $value.join(',')
+      }
+      "--${flag.regsubst('_', '-')}=${_value}"
+    }
+
+    # Check if namespace exists, otherwise trigger install
+    # TODO: trigger install if install_flags have changed?
+    Exec <| title == 'k8s apiserver wait online' |>
+    -> exec { 'Verify FluxCD install':
+      path    => $facts['path'],
+      command => 'true',
+      unless  => "kubectl --kubeconfig ${kubeconfig} get namespace flux-system",
+    }
+    ~> exec { 'FluxCD install':
+      command     => "flux install --export ${install_flags.join(' ')} | kubectl --kubeconfig ${kubeconfig} apply --server-side --force-conflicts -f -",
+      refreshonly => true,
+      path        => $facts['path'],
+      require     => File['/usr/local/bin/flux'],
+    }
+    # If kubeconfig is managed, ensure it exists before Flux
+    File <| title == $kubeconfig |> -> Exec['FluxCD install']
+    Kubeconfig <| title == $kubeconfig |> -> Exec['FluxCD install']
+
+    if $upgrade {
+      # Trigger (re)install on every version change
+      Archive['FluxCD CLI'] ~> Exec['FluxCD install']
+    }
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -13,6 +13,10 @@
       "version_requirement": ">= 4.0.0 < 9.0.0"
     },
     {
+      "name": "puppet-extlib",
+      "version_requirement": ">= 7.5.2 < 8.0.0"
+    },
+    {
       "name": "puppetlabs-stdlib",
       "version_requirement": ">= 9.0.0 < 10.0.0"
     },

--- a/spec/classes/install/fluxcd_spec.rb
+++ b/spec/classes/install/fluxcd_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'k8s::install::fluxcd' do
+  let(:pre_condition) do
+    <<~PUPPET
+      include k8s
+
+      function extlib::version_latest_github(String[1] $pkg) {
+        return 'v1.2.3'
+      }
+    PUPPET
+  end
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+
+      context "with ensure => present" do
+        let(:params) do
+          {
+            ensure: 'present'
+          }
+        end
+
+        it do
+          is_expected.to contain_archive('FluxCD CLI')
+                         .with_source('https://github.com/fluxcd/flux2/releases/download/v1.2.3/flux_1.2.3_linux_amd64.tar.gz')
+                         .with_extract_command("tar -C /usr/local/bin -xf %s  flux")
+                         .with_creates('/usr/local/bin/flux')
+        end
+
+        it do
+          is_expected.to contain_file('/usr/local/bin/flux')
+                         .with_ensure('file')
+                         .with_mode('0755')
+                         .that_requires('Archive[FluxCD CLI]')
+        end
+      end
+
+      context "with ensure => latest" do
+        let(:params) do
+          {
+            ensure: 'latest'
+          }
+        end
+
+        it do
+          is_expected.to contain_archive('FluxCD CLI')
+                         .with_source('https://github.com/fluxcd/flux2/releases/download/v1.2.3/flux_1.2.3_linux_amd64.tar.gz')
+                         .with_extract_command("tar -C /usr/local/bin -xf %s --transform='s/flux/flux-1.2.3/' flux")
+                         .with_creates('/usr/local/bin/flux-1.2.3')
+        end
+
+        it do
+          is_expected.to contain_file('/usr/local/bin/flux')
+                         .with_ensure('link')
+                         .with_target('/usr/local/bin/flux-1.2.3')
+                         .that_requires('Archive[FluxCD CLI]')
+        end
+      end
+
+      context "with install => true" do
+        let(:params) do
+          {
+            install: true
+          }
+        end
+
+        it do
+          is_expected.to contain_exec('FluxCD install')
+                         .with_command('flux install --export  | kubectl --kubeconfig /root/.kube/config apply --server-side --force-conflicts -f -')
+                         .with_refreshonly(true)
+                         .that_requires('File[/usr/local/bin/flux]')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Adds the manifests we've been using to install FluxCD on some of our local clusters and administrative nodes.
Requires https://github.com/voxpupuli/puppet-extlib/pull/259 for `ensure => present`/` latest`.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
