### PR TITLE
Etcd log level configuration

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1475,7 +1475,7 @@ The following parameters are available in the `k8s::server::etcd::setup` class:
 * [`key_file`](#-k8s--server--etcd--setup--key_file)
 * [`listen_client_urls`](#-k8s--server--etcd--setup--listen_client_urls)
 * [`listen_peer_urls`](#-k8s--server--etcd--setup--listen_peer_urls)
-* [`logging_level`](#-k8s--server--etcd--setup--logging_level)
+* [`log_level`](#-k8s--server--etcd--setup--log_level)
 * [`package`](#-k8s--server--etcd--setup--package)
 * [`peer_auto_tls`](#-k8s--server--etcd--setup--peer_auto_tls)
 * [`peer_cert_file`](#-k8s--server--etcd--setup--peer_cert_file)
@@ -1657,7 +1657,7 @@ The peer urls to listen on
 
 Default value: `['https://[::]:2380']`
 
-##### <a name="-k8s--server--etcd--setup--logging_level"></a>`logging_level`
+##### <a name="-k8s--server--etcd--setup--log_level"></a>`log_level`
 
 Data type: `Enum['debug', 'info', 'warn', 'error', 'panic', 'fatal']`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1475,6 +1475,7 @@ The following parameters are available in the `k8s::server::etcd::setup` class:
 * [`key_file`](#-k8s--server--etcd--setup--key_file)
 * [`listen_client_urls`](#-k8s--server--etcd--setup--listen_client_urls)
 * [`listen_peer_urls`](#-k8s--server--etcd--setup--listen_peer_urls)
+* [`logging_level`](#-k8s--server--etcd--setup--logging_level)
 * [`package`](#-k8s--server--etcd--setup--package)
 * [`peer_auto_tls`](#-k8s--server--etcd--setup--peer_auto_tls)
 * [`peer_cert_file`](#-k8s--server--etcd--setup--peer_cert_file)
@@ -1655,6 +1656,14 @@ Data type: `Array[Stdlib::HTTPUrl]`
 The peer urls to listen on
 
 Default value: `['https://[::]:2380']`
+
+##### <a name="-k8s--server--etcd--setup--logging_level"></a>`logging_level`
+
+Data type: `Enum['debug', 'info', 'warn', 'error', 'panic', 'fatal']`
+
+The logging level for etcd
+
+Default value: `'info'`
 
 ##### <a name="-k8s--server--etcd--setup--package"></a>`package`
 

--- a/manifests/server/etcd/setup.pp
+++ b/manifests/server/etcd/setup.pp
@@ -21,7 +21,7 @@
 # @param key_file path to the key file
 # @param listen_client_urls The client urls to listen on
 # @param listen_peer_urls The peer urls to listen on
-# @param logging_level The logging level for etcd
+# @param log_level The logging level for etcd
 # @param package etcd package name
 # @param peer_auto_tls Use peer auto tls
 # @param peer_cert_file path to the peer cert file
@@ -78,7 +78,7 @@ class k8s::server::etcd::setup (
   Optional[Integer[0, 65535]] $uid        = undef,
   Optional[Integer[0, 65535]] $gid        = undef,
 
-  Enum['debug', 'info', 'warn', 'error', 'panic', 'fatal'] $logging_level = 'info',
+  Enum['debug', 'info', 'warn', 'error', 'panic', 'fatal'] $log_level = 'info',
 ) {
   if defined(Class['k8s::server::etcd']) {
     $_k8s_server_etcd_self_signed_tls = $k8s::server::etcd::self_signed_tls
@@ -217,7 +217,7 @@ class k8s::server::etcd::setup (
         auto_compaction_retention   => $auto_compaction_retention,
         initial_cluster_state       => $initial_cluster_state,
         initial_cluster_token       => $initial_cluster_token,
-        logging_level               => $logging_level,
+        log_level                   => $log_level,
       }),
       notify  => Service['etcd'];
 

--- a/manifests/server/etcd/setup.pp
+++ b/manifests/server/etcd/setup.pp
@@ -21,6 +21,7 @@
 # @param key_file path to the key file
 # @param listen_client_urls The client urls to listen on
 # @param listen_peer_urls The peer urls to listen on
+# @param logging_level The logging level for etcd
 # @param package etcd package name
 # @param peer_auto_tls Use peer auto tls
 # @param peer_cert_file path to the peer cert file
@@ -76,6 +77,8 @@ class k8s::server::etcd::setup (
   String[1] $group                        = 'etcd',
   Optional[Integer[0, 65535]] $uid        = undef,
   Optional[Integer[0, 65535]] $gid        = undef,
+
+  Enum['debug', 'info', 'warn', 'error', 'panic', 'fatal'] $logging_level = 'info',
 ) {
   if defined(Class['k8s::server::etcd']) {
     $_k8s_server_etcd_self_signed_tls = $k8s::server::etcd::self_signed_tls
@@ -214,6 +217,7 @@ class k8s::server::etcd::setup (
         auto_compaction_retention   => $auto_compaction_retention,
         initial_cluster_state       => $initial_cluster_state,
         initial_cluster_token       => $initial_cluster_token,
+        logging_level               => $logging_level,
       }),
       notify  => Service['etcd'];
 

--- a/spec/classes/server/etcd/setup_spec.rb
+++ b/spec/classes/server/etcd/setup_spec.rb
@@ -65,6 +65,26 @@ describe 'k8s::server::etcd::setup' do
       it { is_expected.to contain_file('/etc/etcd/cluster.conf') }
       it { is_expected.to contain_systemd__unit_file('etcd.service') }
       it { is_expected.to contain_service('etcd').with_ensure('running').that_subscribes_to('File[/etc/etcd/etcd.conf]') }
+
+      context 'with default logging_level' do
+        it {
+          is_expected.to contain_file('/etc/etcd/etcd.conf').with_content(%r{^ETCD_LOG_LEVEL="info"$})
+        }
+      end
+
+      context 'with logging_level => debug' do
+        let(:params) { super().merge(logging_level: 'debug') }
+
+        it {
+          is_expected.to contain_file('/etc/etcd/etcd.conf').with_content(%r{^ETCD_LOG_LEVEL="debug"$})
+        }
+      end
+
+      context 'with invalid logging_level' do
+        let(:params) { super().merge(logging_level: 'verbose') }
+
+        it { is_expected.to compile.and_raise_error(%r{parameter 'logging_level'}) }
+      end
     end
   end
 end

--- a/spec/classes/server/etcd/setup_spec.rb
+++ b/spec/classes/server/etcd/setup_spec.rb
@@ -66,24 +66,24 @@ describe 'k8s::server::etcd::setup' do
       it { is_expected.to contain_systemd__unit_file('etcd.service') }
       it { is_expected.to contain_service('etcd').with_ensure('running').that_subscribes_to('File[/etc/etcd/etcd.conf]') }
 
-      context 'with default logging_level' do
+      context 'with default log_level' do
         it {
           is_expected.to contain_file('/etc/etcd/etcd.conf').with_content(%r{^ETCD_LOG_LEVEL="info"$})
         }
       end
 
-      context 'with logging_level => debug' do
-        let(:params) { super().merge(logging_level: 'debug') }
+      context 'with log_level => debug' do
+        let(:params) { super().merge(log_level: 'debug') }
 
         it {
           is_expected.to contain_file('/etc/etcd/etcd.conf').with_content(%r{^ETCD_LOG_LEVEL="debug"$})
         }
       end
 
-      context 'with invalid logging_level' do
-        let(:params) { super().merge(logging_level: 'verbose') }
+      context 'with invalid log_level' do
+        let(:params) { super().merge(log_level: 'verbose') }
 
-        it { is_expected.to compile.and_raise_error(%r{parameter 'logging_level'}) }
+        it { is_expected.to compile.and_raise_error(%r{parameter 'log_level'}) }
       end
     end
   end

--- a/templates/server/etcd/etcd.conf.epp
+++ b/templates/server/etcd/etcd.conf.epp
@@ -28,7 +28,7 @@
   Optional[Enum['existing', 'new']] $initial_cluster_state = undef,
   Optional[String] $initial_cluster_token = undef,
 
-  Boolean $debug = false,
+  Enum['debug', 'info', 'warn', 'error', 'panic', 'fatal'] $logging_level,
 | -%>
 # Managed by Puppet
 
@@ -90,9 +90,4 @@ ETCD_PEER_AUTO_TLS="<%= $peer_auto_tls %>"
 <% } -%>
 
 #[logging]
-# Depricated in etcd v3.5.0
-ETCD_DEBUG=<%= $debug %>
-# Supported from etcd v3.4.0
-<% if $debug { -%>
-ETCD_LOG_LEVEL="debug"
-<% } -%>
+ETCD_LOG_LEVEL="<%= $logging_level %>"

--- a/templates/server/etcd/etcd.conf.epp
+++ b/templates/server/etcd/etcd.conf.epp
@@ -90,4 +90,9 @@ ETCD_PEER_AUTO_TLS="<%= $peer_auto_tls %>"
 <% } -%>
 
 #[logging]
+# Depricated in etcd v3.5.0
 ETCD_DEBUG=<%= $debug %>
+# Supported from etcd v3.4.0
+<% if $debug { -%>
+ETCD_LOG_LEVEL="debug"
+<% } -%>

--- a/templates/server/etcd/etcd.conf.epp
+++ b/templates/server/etcd/etcd.conf.epp
@@ -28,7 +28,7 @@
   Optional[Enum['existing', 'new']] $initial_cluster_state = undef,
   Optional[String] $initial_cluster_token = undef,
 
-  Enum['debug', 'info', 'warn', 'error', 'panic', 'fatal'] $logging_level,
+  Enum['debug', 'info', 'warn', 'error', 'panic', 'fatal'] $log_level = 'info',
 | -%>
 # Managed by Puppet
 
@@ -90,4 +90,4 @@ ETCD_PEER_AUTO_TLS="<%= $peer_auto_tls %>"
 <% } -%>
 
 #[logging]
-ETCD_LOG_LEVEL="<%= $logging_level %>"
+ETCD_LOG_LEVEL="<%= $log_level %>"


### PR DESCRIPTION
#### Pull Request (PR) description
The ETCD_DEBUG environment variable is deprecated since v3.5, and there is a new option since v3.4 by setting ETCD_LOGGING_LEVEL=debug.

Check: https://etcd.io/docs/v3.4/op-guide/configuration/

This also cause unrecognized variable warning.
```
Jan 30 13:45:54 sa01 etcd[3050583]: {"level":"warn","ts":"2026-01-30T13:45:54.232787Z","caller":"flags/flag.go:93","msg":"unrecognized environment variable","environment-variable":"ETCD_DEBUG=false"}
```

This PR removes the unused debug parameter from the etcd cfg template and introduces a new class parameter to specify the etcd log level.

---
This issue was found by @cowjen01
