### PR TITLE
Fix deprecation warning for to_yaml

### DIFF
--- a/manifests/install/crictl.pp
+++ b/manifests/install/crictl.pp
@@ -65,7 +65,7 @@ class k8s::install::crictl (
 
   file { '/etc/crictl.yaml':
     ensure  => $k8s::ensure,
-    content => $config.to_yaml,
+    content => $config.stdlib::to_yaml,
     require => $config_require,
   }
 }

--- a/manifests/node/kube_proxy.pp
+++ b/manifests/node/kube_proxy.pp
@@ -88,7 +88,7 @@ class k8s::node::kube_proxy (
 
   file { '/etc/kubernetes/kube-proxy.conf':
     ensure  => $_ensure,
-    content => to_yaml($config_hash),
+    content => stdlib::to_yaml($config_hash),
     owner   => $k8s::user,
     group   => $k8s::group,
     notify  => Service['kube-proxy'],

--- a/manifests/node/kubelet.pp
+++ b/manifests/node/kubelet.pp
@@ -207,7 +207,7 @@ class k8s::node::kubelet (
 
   file { '/etc/kubernetes/kubelet.conf':
     ensure  => $ensure,
-    content => to_yaml($config_hash + $config),
+    content => stdlib::to_yaml($config_hash + $config),
     owner   => $k8s::user,
     group   => $k8s::group,
     notify  => Service['kubelet'],

--- a/manifests/server/apiserver.pp
+++ b/manifests/server/apiserver.pp
@@ -166,7 +166,7 @@ class k8s::server::apiserver (
     $_image = "${container_registry}/${container_image}:${pick($container_image_tag, "v${k8s::version}")}"
     file { '/etc/kubernetes/manifests/kube-apiserver.yaml':
       ensure  => $ensure,
-      content => to_yaml({
+      content => stdlib::to_yaml({
         apiVersion => 'apps/v1',
         kind       => 'DaemonSet',
         metadata   => {

--- a/manifests/server/resources.pp
+++ b/manifests/server/resources.pp
@@ -175,7 +175,7 @@ class k8s::server::resources (
           },
         },
         data     => {
-          kubeconfig => to_yaml({
+          kubeconfig => stdlib::to_yaml({
             apiVersion        => 'v1',
             kind              => 'Config',
             'current-context' => 'local',

--- a/manifests/server/resources/bootstrap.pp
+++ b/manifests/server/resources/bootstrap.pp
@@ -58,7 +58,7 @@ class k8s::server::resources::bootstrap (
         },
         data     => {
           ca         => String(Binary.new($facts['k8s_ca']), '%s'),
-          kubeconfig => to_yaml({
+          kubeconfig => stdlib::to_yaml({
             apiVersion        => 'v1',
             kind              => 'Config',
             clusters          => [

--- a/manifests/server/resources/kube_proxy.pp
+++ b/manifests/server/resources/kube_proxy.pp
@@ -130,7 +130,7 @@ class k8s::server::resources::kube_proxy (
           },
         },
         data     => {
-          'kube-proxy.conf' => to_yaml({
+          'kube-proxy.conf' => stdlib::to_yaml({
             apiVersion       => 'kubeproxy.config.k8s.io/v1alpha1',
             kind             => 'KubeProxyConfiguration',
             clusterCIDR      => flatten($cluster_cidr).join(','),


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
Fixes deprecation spam from the puppetserver log
```
2026-03-16T09:25:23.227+01:00 WARN [qtp949192205-154] [puppetserver] Puppet This function is deprecated, please use stdlib::to_yaml instead. at ["/etc/puppetlabs/code/environments/production/modules/k8s/manifests/node/kubelet.pp", 206]:["/etc/puppetlabs/code/environments/production/modules/k8s/manifests/node.pp", 80]
```

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
