### PR TITLE
Inject default facts into all tests

### DIFF
--- a/spec/support/default_facts.rb
+++ b/spec/support/default_facts.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+if File.exist?(File.expand_path('../default_module_facts.yml', __dir__))
+  module_facts = YAML.safe_load(File.read(File.expand_path('../default_module_facts.yml', __dir__))) || {}
+  RSpec.configure do |c|
+    c.default_facts = c.default_facts.merge(module_facts)
+  end
+end


### PR DESCRIPTION
#### Pull Request (PR) description
Includes default facts in all tests. This fixes the warning when running tests saying _Could not retrieve fact networking.ip_. See example:
```
No facts were found in the FacterDB for Facter v5.1.0 on {"os.name"=>"Ubuntu", "os.release.full"=>"/^20\\.04/", "os.hardware"=>"x86_64"}, using v4.11.0 instead
checking for kubectl... yes
............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................Could not retrieve fact networking.ip
.Could not retrieve fact networking.ip
.Could not retrieve fact networking.ip
.Could not retrieve fact networking.ip
.Could not retrieve fact networking.ip
```

After the fix, running the test looks clean:
```
No facts were found in the FacterDB for Facter v5.1.0 on {"os.name"=>"Ubuntu", "os.release.full"=>"/^20\\.04/", "os.hardware"=>"x86_64"}, using v4.11.0 instead
checking for kubectl... yes
...............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

Coverage Report:

Total resources:   293
Touched resources: 108
Resource coverage: 36.86%
```




